### PR TITLE
Collection to redirect

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,5 +5,22 @@ return [
     'baseUrl' => '',
     'title' => 'LibreSign - Electronic signature of digital documents',
     'description' => 'Electronic signature of digital documents',
-    'collections' => [],
+    'collections' => [
+        'redirect' => [
+            'extends' => '_layouts.redirect301',
+            'path' => function($page) {
+                return $page->from;
+            },
+            'items' => [
+                [
+                    'from' => '/teste',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/teste2',
+                    'to' => '/',
+                ],
+            ],
+        ]
+    ],
 ];

--- a/config.php
+++ b/config.php
@@ -13,14 +13,66 @@ return [
             },
             'items' => [
                 [
-                    'from' => '/teste',
+                    'from' => '/account',
                     'to' => '/',
                 ],
                 [
-                    'from' => '/teste2',
+                    'from' => '/atendimento-lgpd',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/cadastre-se',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/categoria-produto/cloud',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/doe',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/envolva-se',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/loja',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/password-reset',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/politica-de-privacidade',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/produto/libresign-cloud',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/recursos',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/register',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/sobre',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/suporte',
+                    'to' => '/',
+                ],
+                [
+                    'from' => '/termos-e-condicoes',
                     'to' => '/',
                 ],
             ],
-        ]
+        ],
     ],
 ];

--- a/source/_layouts/redirect301.blade.php
+++ b/source/_layouts/redirect301.blade.php
@@ -1,5 +1,5 @@
 <html>
     <head>
-        <meta http-equiv="refresh" content="0; url={{ $page->to }}" />
+        <meta http-equiv="refresh" content="1; url={{ $page->to }}" />
     </head>
 </html>

--- a/source/_layouts/redirect301.blade.php
+++ b/source/_layouts/redirect301.blade.php
@@ -1,0 +1,5 @@
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0; url={{ $page->to }}" />
+    </head>
+</html>


### PR DESCRIPTION
## What this made
Now we can have this files:
```
build_local/teste
└── index.html
build_local/teste2
└── index.html
```
And the file contents are similar to this, only changing the _url_ because is the _to-key_ from each item of collection:
```html
<html>
    <head>
        <meta http-equiv="refresh" content="0; url=/" />
    </head>
</html>
```

Looking the documentation of Redirects from _Google Search Central_ I found that:

https://developers.google.com/search/docs/crawling-indexing/301-redirects
(access this link and look the table)

Then, the meta refresh will solve our problem about redirect.

For now, we only need to list all pages that was indexed by Google and implement the redirect to home ( / ). We can ignore the domain because the domain didn't change.