### PR TITLE
Make possible choose between watch and serve

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -8,4 +8,8 @@ if [ ! -d "vendor" ]; then
     composer i
 fi
 
-npm run watch
+if [[ "$SERVER_MODE" == 'watch' ]]; then
+    npm run watch
+else
+    php ./vendor/bin/jigsaw serve --host 0.0.0.0 --port 3000
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ npm-debug.log
 # /build_staging/
 /build_production/
 /source/assets/build/
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,14 @@ services:
         - NODE_MAJOR=${NODE_MAJOR:-20}
     ports:
       - "127.0.0.1:${HTTP_PORT:-80}:3000"
-      - "127.0.0.1:${HTTP_PORT:-8080}:3001"
+      - "127.0.0.1:${HTTP_PORT_BROWSERSYNC:-8080}:3001"
     volumes:
       - .:/var/www/html
     environment:
       - HOST_UID=${HOST_UID:-1000}
       - HOST_GID=${HOST_GID:-1000}
+      # The condition is to check if is watch, if not will run only the php built-in http server
+      - SERVER_MODE=${SERVER_MODE:-watch}
       - TZ=${TZ:-America/Sao_Paulo}
       - XDEBUG_CONFIG=${XDEBUG_CONFIG:-client_host=172.17.0.1 start_with_request=yes}
       - XDEBUG_MODE=${XDEBUG_MODE:-debug}


### PR DESCRIPTION
This is necessary to don't run jigsaw build to each code change because sometimes a change could break the code and the watch will start a loop until the code is fixed and this could freeze the machine using a lot of hardware resources.