### PR TITLE
chore: restart unless stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
 
   web:
     image: nginx:alpine
+    restart: unless-stopped
     ports:
       - 127.0.0.1:${HTTP_PORT:-80}:80
     volumes:
@@ -11,6 +12,7 @@ services:
   php:
     build:
       context: .docker/php
+    restart: unless-stopped
     ports:
       - "127.0.0.1:${HTTP_PORT:-3000}:3000"
       - "127.0.0.1:${HTTP_PORT_BROWSERSYNC:-3001}:3001"


### PR DESCRIPTION
I already fixed at production, service was started with this setting.

This is necessary to restart the docker services after a restart of host of docker.