### PR TITLE
 chore: fix broken links and clean up image alternatives

### DIFF
--- a/source/_layouts/footer.blade.php
+++ b/source/_layouts/footer.blade.php
@@ -89,7 +89,7 @@
                 <div class="col-md-8">
                     <ul class="ud-footer-bottom-left">
                         <li>
-                            <a href="{{ locale_url($page, 'contact-us') }}privacy-policy">{{ $page->t("Privacy policy")}}</a>
+                            <a href="{{ locale_url($page, 'privacy-policy') }}">{{ $page->t("Privacy policy")}}</a>
                         </li>
                     </ul>
                 </div>

--- a/source/_layouts/footer.blade.php
+++ b/source/_layouts/footer.blade.php
@@ -1,14 +1,14 @@
 <footer class="ud-footer wow fadeInUp mt-5" data-aos-delay=".15s">
     <div class="shape shape-1">
-        <img src="{{ $page->baseUrl }}assets/images/footer/shape-1.svg" alt="shape" />
+        <img src="{{ $page->baseUrl }}assets/images/footer/shape-1.svg" alt="" />
     </div>
 
     <div class="shape shape-2">
-        <img src="{{ $page->baseUrl }}assets/images/footer/shape-2.svg" alt="shape" />
+        <img src="{{ $page->baseUrl }}assets/images/footer/shape-2.svg" alt="" />
     </div>
 
     <div class="shape shape-3">
-        <img src="{{ $page->baseUrl }}assets/images/footer/shape-3.svg" alt="shape" />
+        <img src="{{ $page->baseUrl }}assets/images/footer/shape-3.svg" alt="" />
     </div>
 
     <div class="ud-footer-widgets">
@@ -17,7 +17,7 @@
                 <div class="col-xl-3 col-lg-4 col-md-6">
                     <div class="ud-widget">
                         <a href="{{ locale_url($page, 'contact-us') }}#home" class="ud-footer-logo">
-                            <img src="{{ $page->baseUrl }}assets/images/logo/logo.svg" alt="logo" />
+                            <img src="{{ $page->baseUrl }}assets/images/logo/logo.svg" alt="LibreSign" />
                         </a>
                         <p class="ud-widget-desc">
                             {{ $page->t("We create digital experiences for brands and companies by using technology.")}}
@@ -47,7 +47,7 @@
                     </div>
                     <div class="ud-widget col-lg-5">
                         <a target="_blank" href="https://www.somos.coop.br/" title="{{ $page->t("Page to national movement that valozie cooperative initiatives.")}}">
-                            <img src="{{ $page->baseUrl }}assets/images/icon/somoscoop.png" alt="icon_somos_coop">
+                            <img src="{{ $page->baseUrl }}assets/images/icon/somoscoop.png" alt="We areCoop">
                         </a>
                     </div>
                 </div>

--- a/source/_layouts/header.blade.php
+++ b/source/_layouts/header.blade.php
@@ -4,7 +4,7 @@
         <div class="col-lg-12">
           <nav class="navbar navbar-expand-lg">
             <a class="navbar-brand" href="{{ locale_url($page, '')  }}">
-              <img src="{{ $page->baseUrl }}assets/images/logo/logo.svg" alt="Logo" />
+              <img src="{{ $page->baseUrl }}assets/images/logo/logo.svg" alt="LibreSign" />
             </a>
             <button class="navbar-toggler" title="{{$page->t("Toggle navigation menu")}}">
               <span class="toggler-icon"> </span>

--- a/source/_layouts/post_base.blade.php
+++ b/source/_layouts/post_base.blade.php
@@ -24,17 +24,17 @@
               <div class="ud-blog-details-image">
                 <img
                   src="{{ $page->banner }}"
-                  alt="blog details"
+                  alt=""
                 />
                 <div class="ud-blog-overlay">
                   <div class="ud-blog-overlay-content">
                     <div class="ud-blog-author">
                       @if($page->author == 'LibreSign')
                         <img src="{{$page->baseUrl}}assets/images/logo/Avatar-LibreSign.png"
-                        alt="{{ $page->author }}" />
+                        alt="" />
                       @else
                         <img src="https://www.gravatar.com/avatar/{{$page->gravatar}}?size=40"
-                        alt="{{ $page->author }}" />
+                        alt="" />
                       @endif
                       <span>
                         @php
@@ -89,14 +89,14 @@
                             <a href="{{ locale_url($page, 'team/' . \Illuminate\Support\Str::slug($article->author)) }}">
                               <img
                                 src="{{$page->baseUrl}}assets/images/logo/Avatar-LibreSign.png"
-                                alt="{{ $article->author }}"
+                                alt=""
                               />
                             </a>
                           @else
                             <a href="{{ locale_url($page, 'team/' . \Illuminate\Support\Str::slug($article->author)) }}">
                               <img
                                   src="https://www.gravatar.com/avatar/{{ $article->gravatar }}?size=40"
-                                  alt="{{ $article->author }}"
+                                  alt=""
                                 />
                             </a>
                           @endif

--- a/source/_layouts/team-member.blade.php
+++ b/source/_layouts/team-member.blade.php
@@ -16,14 +16,14 @@
     </section>
     <!-- ====== Banner End ====== -->
 
-    
+
     <section id="team" class="ud-team">
         <div class="container">
           <div class="row">
             <div class="col-lg-12">
-              <div class="ud-section-title mx-auto text-center">                
+              <div class="ud-section-title mx-auto text-center">
                 <p>
-                  {{ $page->bio }} 
+                  {{ $page->bio }}
                 </p>
               </div>
             </div>
@@ -42,7 +42,7 @@
                   @endphp
                   <img
                     src="{{ $gravatar }}"
-                    alt="{{ $page->name }}"
+                    alt=""
                     class="shape shape-1 mb-5"
                   />
                 </div>
@@ -61,5 +61,5 @@
             </div>
           </div>
         </div>
-      </section>  
+      </section>
 @endsection

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -23,15 +23,15 @@
               </ul>
             </div>
             <div class="ud-hero-image wow fadeInUp" data-aos-delay=".25s">
-              <img src="{{ $page->baseUrl }}assets/images/print_main_screen.png" alt="print_main_screen"/>
+              <img src="{{ $page->baseUrl }}assets/images/print_main_screen.png" alt=""/>
               <img
                 src="{{ $page->baseUrl }}assets/images/dotted-shape.svg"
-                alt="shape"
+                alt=""
                 class="shape shape-1"
               />
               <img
                 src="{{ $page->baseUrl }}assets/images/dotted-shape.svg"
-                alt="shape"
+                alt=""
                 class="shape shape-2"
               />
             </div>
@@ -100,7 +100,7 @@
             </div>
           </div>
           <div class="ud-about-image">
-            <img src="{{ $page->baseUrl }}assets/images/about/about-image.svg" alt="about-image" />
+            <img src="{{ $page->baseUrl }}assets/images/about/about-image.svg" alt="" />
           </div>
         </div>
       </div>
@@ -189,7 +189,7 @@
               </div>
           </div>
           <div class="col-lg-4">
-            <img src="{{ $page->baseUrl }}assets/images/mobile_libresign.png" alt="print_main_screen"/>
+            <img src="{{ $page->baseUrl }}assets/images/mobile_libresign.png" alt=""/>
           </div>
           <div class="col-lg-12 d-flex justify-content-center mt-5">
             <a href="{{ locale_url($page, 'contact-us') }}" class="ud-main-btn ud-border-btn">
@@ -205,7 +205,7 @@
     <!-- ====== FAQ Start ====== -->
     <section id="faq" class="ud-faq">
       <div class="shape">
-        <img src="{{ $page->baseUrl }}assets/images/faq/shape.svg" alt="shape" />
+        <img src="{{ $page->baseUrl }}assets/images/faq/shape.svg" alt="" />
       </div>
       <div class="container">
         <div class="row">

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -192,7 +192,7 @@
             <img src="{{ $page->baseUrl }}assets/images/mobile_libresign.png" alt="print_main_screen"/>
           </div>
           <div class="col-lg-12 d-flex justify-content-center mt-5">
-            <a href="{{ locale_url($page, 'contact-us') }}contact-us" class="ud-main-btn ud-border-btn">
+            <a href="{{ locale_url($page, 'contact-us') }}" class="ud-main-btn ud-border-btn">
               {{ $page->t('Talk to sales') }}
             </a>
           </div>

--- a/source/posts.blade.php
+++ b/source/posts.blade.php
@@ -27,7 +27,7 @@
               <div class="ud-single-blog">
                 <div class="ud-blog-image">
                   <a href="{{ $post->getUrl() }}">
-                    <img src="{{ $post->cover_image }}" alt="{{ $page->t($post->title) }}" />
+                    <img src="{{ $post->cover_image }}" alt="" />
                   </a>
                 </div>
                 <div class="ud-blog-content">

--- a/source/pricing.blade.php
+++ b/source/pricing.blade.php
@@ -43,7 +43,7 @@
                 </div>
               @endif
               <div class="ud-pricing-footer">
-                <a href="{{ locale_url($page, 'contact-us') }}contact-us" class="ud-main-btn ud-border-btn">
+                <a href="{{ locale_url($page, 'contact-us') }}" class="ud-main-btn ud-border-btn">
                   {{ $page->t('Under Consultation') }}
                 </a>
               </div>
@@ -89,7 +89,7 @@
       </div>
 
       <div class="ud-pricing-footer text-center mt-5">
-        <a href="{{ locale_url($page, 'contact-us') }}contact-us" class="ud-main-btn ud-white-btn mt-1">
+        <a href="{{ locale_url($page, 'contact-us') }}" class="ud-main-btn ud-white-btn mt-1">
           {{ $page->t('Under Consultation') }}
         </a>
       </div>
@@ -127,7 +127,7 @@
         </div>
       </div>
       <div class="ud-pricing-footer text-center mt-5">
-        <a href="{{ locale_url($page, 'contact-us') }}contact-us" class="ud-main-btn ud-white-btn mt-1">
+        <a href="{{ locale_url($page, 'contact-us') }}" class="ud-main-btn ud-white-btn mt-1">
           {{ $page->t('Under Consultation') }}
         </a>
       </div>


### PR DESCRIPTION
Does two chores. I recommend reading one commit at a time!

## Broken Links

Fixes a bunch of broken links. It looks like this was probably just a screwed up bulk find and replace.

Most links to the `/contact-us` page were broken. Then your privacy policy in your footer was broken too! :fearful:

This fixes them all, so all links will be working again. :+1:

## Alt Text

I elaborate on this in https://github.com/LibreSign/site/issues/345, but TL;DR, decorative images should **not** have alt text defined. It makes for a worse experience for users of assistive technologies, and is just a waste of bytes to ship to users.

* All images that had `[alt=shape]` were 100% decorative.
* Logos should not have an alt text of "logo", but rather what it is the logo of. Fulfil the _purpose_ of the image!
  * For the LibreSign logo, I used "LibreSign"
  * For the somoscoop logo, I used "We areCoop" which is what is used on their official website.
* For the blog post banner, removes it as it was useless before.
* For the blog post author, removes it as the author name is already written adjacent to it.
* For team member, removes it as the team members name is already written just above it.
* On the list of all blog posts, removes it from the cover images because the post title is already written just below.
* You get the idea, if the content is decorative or if whatever the image was trying to achieve is already done by adjacent content, then the alt text should be `alt=""`.

### Context

The alt attribute, short for **alternate**, is an accessibility feature that determines what it displayed when the image can not be loaded. For example:

* Poor network conditions
* Screen readers (such as a visually impaired users)

> Images with no semantic meaning—such as those which are solely decorative—or of limited informational value, should have their alt attributes set to the empty string ("").
>
> — [MDN: Decorative images](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images)

> Such images are decorative, but still form part of the content. In these cases, the alt attribute must be present but its value must be the empty string.
>
> — [W3C: HTML Specification](https://html.spec.whatwg.org/multipage/images.html#a-purely-decorative-image-that-doesn't-add-any-information)

> Null alt attributes are also sometimes known as empty alt attributes. They are made by including no information between the opening and closing quotes of an alt attribute. Decorative images do not communicate information that is required to understand the website's overall meaning.
>
> — [The Accessibility Project: Checklist](https://www.a11yproject.com/checklist/)

> Another corollary is that the alt attribute's value should not repeat information that is already provided in the prose next to the image.
> 
> — [W3C: HTML Specifications](https://html.spec.whatwg.org/multipage/images.html#a-purely-decorative-image-that-doesn't-add-any-information)

## Related

* Closes https://github.com/LibreSign/site/issues/336
* Closes https://github.com/LibreSign/site/issues/345