### PR TITLE
fix: avoid nginx redirect cycles

### DIFF
--- a/.docker/nginx/app.conf
+++ b/.docker/nginx/app.conf
@@ -1,10 +1,10 @@
 server {
     listen 80;
-    index index.php;
+    index index.html index.php;
     root /var/www/html;
 
     location ~ \.(ico|css|js|gif|jpe?g|png|woff2?|ttf|otf|svg|eot)$ {
-        try_files $uri /$request_uri;
+        try_files $uri =404;
         # Optional: Don't log access to other assets
         access_log off;
     }
@@ -17,8 +17,17 @@ server {
         fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 
+    location = / {
+        try_files /index.html =404;
+        gzip_static on;
+    }
+
+    location ~ \.html$ {
+        try_files $uri =404;
+    }
+
     location / {
-        try_files $uri $uri/index.html;
+        try_files $uri $uri/index.html $uri/ =404;
         gzip_static on;
     }
 


### PR DESCRIPTION
## Summary
- stop recursive internal redirects in the Nginx static-site config
- return 404 for missing assets and sensitive paths like /.env instead of 500
- serve generated HTML files explicitly so pretty URLs such as /account and /pricing keep working

## Validation
- docker compose exec web nginx -t
- docker compose exec web nginx -s reload
- curl probes against /account, /pricing, /.env, /robots.txt and /favicon.ico
- verified web logs no longer show "rewrite or internal redirection cycle" after the reload

## Notes
- local build_local in this worktree does not currently include a root index.html, so / returns 404 locally after the loop fix; that is separate from the Nginx redirect-cycle bug being fixed here