### PR TITLE
fix: ignore generated translation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 /.vscode/
 npm-debug.log
 /source/assets/sitemap.xml
+/source/[a-z][a-z]/
+/source/[a-z][a-z]-[A-Z][A-Z]/
+/source/_posts/_tmp/
 # Optional ignores
 # /build_staging/
 /build_production/


### PR DESCRIPTION
## Summary
- ignore generated translated source directories under source/
- ignore temporary translated posts under source/_posts/_tmp/
- avoid git pollution when translation cleanup does not run to completion

## Testing
- not run (gitignore-only change)