### PR TITLE
fix: clarify empty pricing comparison message

### DIFF
--- a/source/pricing.blade.php
+++ b/source/pricing.blade.php
@@ -62,40 +62,64 @@
           'key' => strtolower($planName),
           'label' => $planName,
         ], array_keys((array) $page->prices));
+
+        $comparisonRows = array_values(array_filter(
+          (array) $page->optionsServicesLibresign,
+          static function ($optionList) use ($comparePlans): bool {
+            foreach ($comparePlans as $plan) {
+              $value = $optionList->{$plan['key']} ?? null;
+              if (is_bool($value) || (is_string($value) && $value !== '') || is_numeric($value)) {
+                return true;
+              }
+            }
+            return false;
+          }
+        ));
       @endphp
 
-      <h2 class="display-6 text-center mb-4">{{ $page->t('Compare plans')}}</h2>
+      <h2 class="display-6 text-center mb-4">{{ $page->t(count($comparePlans) > 1 ? 'Compare plans' : 'Plan details') }}</h2>
 
-      <div class="table-responsive">
-        <table class="table text-center">
+      @if (!empty($comparisonRows))
+        <div class="table-responsive">
+          <table class="table text-center">
 
-          <thead>
-            <tr>
-              <th style="width: 34%;"></th>
-              @foreach ($comparePlans as $plan)
-                <th style="width: 22%;">{{ $page->t($plan['label']) }}</th>
+            <thead>
+              <tr>
+                <th style="width: 34%;"></th>
+                @foreach ($comparePlans as $plan)
+                  <th style="width: 22%;">{{ $page->t($plan['label']) }}</th>
+                @endforeach
+              </tr>
+            </thead>
+            <tbody>
+              @foreach ($comparisonRows as $optionList)
+                <tr>
+                  <th scope="row" class="text-start">{{ $page->t($optionList->service) }}</th>
+                  @foreach ($comparePlans as $plan)
+                    @php($planValue = $optionList->{$plan['key']} ?? null)
+                    <td>
+                      @if (is_bool($planValue))
+                        <span class="{{ $planValue ? 'text-success' : 'text-danger' }} fw-semibold">
+                          <i class="lni lni-{{ $planValue ? 'checkmark' : 'close' }}"></i>
+                          {{ $page->t($planValue ? 'Included' : 'Not included') }}
+                        </span>
+                      @elseif (is_string($planValue) && $planValue !== '')
+                        {{ $page->t($planValue) }}
+                      @elseif (is_numeric($planValue))
+                        {{ $planValue }}
+                      @else
+                        <span class="text-muted">-</span>
+                      @endif
+                    </td>
+                  @endforeach
+                </tr>
               @endforeach
-            </tr>
-          </thead>
-          @foreach($page->optionsServicesLibresign as $item => $optionList)
-          <tbody>
-            <tr>
-              <th scope="row" class="text-start">{{ $page->t($optionList->service) }}</th>
-              @foreach ($comparePlans as $plan)
-                @php($planValue = $optionList->{$plan['key']} ?? null)
-                <td>
-                  @if (is_bool($planValue))
-                    <i class="lni lni-{{ $planValue == true ? 'checkmark text-success' : 'close text-danger'}}"></i>
-                  @elseif (is_string($planValue) && $planValue !== '')
-                    {{ $page->t($planValue) }}
-                  @endif
-                </td>
-              @endforeach
-            </tr>
-          </tbody>
-          @endforeach
-        </table>
-      </div>
+            </tbody>
+          </table>
+        </div>
+      @else
+        <p class="text-center mb-4">{{ $page->t('This plan does not include a comparison table.') }}</p>
+      @endif
 
       <div class="ud-pricing-footer text-center mt-5">
         <a href="{{ locale_url($page, 'contact-us') }}" class="ud-main-btn ud-white-btn mt-1">


### PR DESCRIPTION
## Summary
- replace ambiguous fallback copy in pricing comparison section
- use neutral wording to avoid suggesting new rows will appear later

## Why
The previous message could imply pending updates and create false expectation for users when no comparison rows exist.

## Testing
- visual check of fallback text path in pricing template