### PR TITLE
fix: ensure mix manifest is built on startup in develop mode

### DIFF
--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -4,12 +4,23 @@
 usermod --non-unique --uid "${HOST_UID}" www-data
 groupmod --non-unique --gid "${HOST_GID}" www-data
 
-if [ ! -d "vendor" ]; then
+if [[ ! -d "vendor" ]]; then
     composer i
 fi
+
+if [[ ! -d "node_modules" ]]; then
+    npm ci
+fi
+
 php-fpm &
+
 if [[ "$SERVER_MODE" == 'watch' ]]; then
     npm run watch
 else
+    if [[ ! -f "source/assets/build/mix-manifest.json" ]]; then
+        echo "Mix manifest missing. Running one-time asset build (npm run dev)..."
+        npm run dev
+    fi
+
     php ./vendor/bin/jigsaw serve --host 0.0.0.0 --port 3000
 fi

--- a/source/_layouts/footer.blade.php
+++ b/source/_layouts/footer.blade.php
@@ -123,7 +123,7 @@
     <script>
       window.baseUrl = "{{ $page->baseUrl === '/' ? '' : $page->baseUrl }}";
     </script>
-    <script defer src="{{ rtrim($page->baseUrl, '/') . mix('js/main.js', 'assets/build') }}"></script>
+        <script defer src="{{ rtrim($page->baseUrl, '/') . mix('js/main.js', 'assets/build') }}"></script>
     <script>
         document.getElementById('back-to-top').onclick = function(e) {
             e.preventDefault()


### PR DESCRIPTION
## Description

Ensures that the Mix manifest is built automatically on the first startup when running in develop mode, preventing the "The Mix manifest does not exist" error.

## Changes

- **entrypoint.sh**: 
  - Added `npm ci` check to ensure node_modules exist before any build steps
  - Added conditional check: if `source/assets/build/mix-manifest.json` is missing in develop mode, runs `npm run dev` once before starting the server
  - Fixed shell syntax consistency with `[[` instead of `[` for better handling of file tests

- **footer.blade.php**: Fixed indentation on script tag (style cleanup)

## Why

In develop mode (without watch), the PHP server starts without running the asset build pipeline. This causes the Jigsaw `mix()` helper to fail when rendering templates because the manifest doesn't exist. This fix ensures the build happens on the first boot if needed, without enabling watch mode which was causing issues in some scenarios.

## Testing

1. Delete `source/assets/build/mix-manifest.json`
2. Rebuild the container or restart the PHP service
3. The container should build assets automatically and start without errors
4. On subsequent restarts, it should skip the build since the manifest exists