### PR TITLE
fix(ci): publish Docker PHP image to LibreSign GHCR namespace

### DIFF
--- a/.github/workflows/docker-php.yml
+++ b/.github/workflows/docker-php.yml
@@ -15,6 +15,8 @@ jobs:
   push_to_registry:
     name: Build image
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/libresign/jigsaw-dev-php
     permissions:
       packages: write
       contents: read
@@ -24,6 +26,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker layers
         id: docker-cache
@@ -54,7 +57,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ steps.dockerfile.outputs.DOCKERFILE }}
           tags: |
-            ghcr.io/librecodecoop/jigsaw-dev-php:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Push container image
@@ -66,8 +69,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ steps.dockerfile.outputs.DOCKERFILE }}
           tags: |
-            ghcr.io/librecodecoop/jigsaw-dev-php:${{ github.sha }}
-            ghcr.io/librecodecoop/jigsaw-dev-php:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache


### PR DESCRIPTION
## Summary
- fix Docker image push target from ghcr.io/librecodecoop to ghcr.io/libresign
- centralize image name in IMAGE_NAME env to avoid namespace drift
- add missing buildx step id used by Available platforms step

## Root cause
The workflow logged in with the repository GITHUB_TOKEN from LibreSign/site but attempted to push to a different GHCR namespace (librecodecoop), causing:
- denied: permission_denied: The requested installation does not exist.

## Validation
- workflow file validates with no editor errors
- change is isolated to docker-php workflow