### PR TITLE
Fix docker entrypoint mode handling and reduce Jigsaw build instability

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -18,6 +18,7 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
     && rm /usr/local/bin/install-php-extensions
 
 COPY xdebug.ini /usr/local/etc/php/conf.d/
+COPY dev.ini /usr/local/etc/php/conf.d/zz-dev.ini
 
 # Install NVM
 RUN export NVM_DIR="/usr/local/nvm" \

--- a/.docker/php/dev.ini
+++ b/.docker/php/dev.ini
@@ -1,0 +1,4 @@
+; Local development PHP overrides
+memory_limit=512M
+log_errors=On
+error_reporting=E_ALL

--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -14,7 +14,12 @@ fi
 
 php-fpm &
 
-if [[ "$SERVER_MODE" == 'watch' ]]; then
+MODE="${SERVER_MODE:-watch}"
+MODE="$(echo "$MODE" | tr '[:upper:]' '[:lower:]' | xargs)"
+
+echo "Starting php container with SERVER_MODE=$MODE"
+
+if [[ "$MODE" == 'watch' ]]; then
     npm run watch
 else
     if [[ ! -f "source/assets/build/mix-manifest.json" ]]; then

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,12 +9,12 @@ use ElaborateCode\JigsawLocalization\LoadLocalization;
 
 $events->beforeBuild([
     LoadLocalization::class,
-    RemoveTranslationFiles::class,
     TranslateContent::class,
 ]);
 
 
 $events->afterBuild([
+    RemoveTranslationFiles::class,
     App\Listeners\GenerateSitemap::class,
     App\Listeners\CleanupCollectionDirectories::class,
 ]);

--- a/listeners/PrepareTranslationFiles.php
+++ b/listeners/PrepareTranslationFiles.php
@@ -124,6 +124,16 @@ class PrepareTranslationFiles
             $translatedName,
             $file->getPathName()
         );
+        $sourceContents = file_get_contents($file->getPathName());
+
+        if ($sourceContents !== false && is_file($destinationPath)) {
+            $destinationContents = file_get_contents($destinationPath);
+            if ($destinationContents !== false && $destinationContents === $sourceContents) {
+                $this->items[] = new SplFileInfo($destinationPath);
+                return;
+            }
+        }
+
         $this->filesystem->ensureDirectoryExists(
             pathinfo($destinationPath, PATHINFO_DIRNAME)
         );

--- a/listeners/RemoveTranslationFiles.php
+++ b/listeners/RemoveTranslationFiles.php
@@ -34,20 +34,28 @@ class RemoveTranslationFiles
             }
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($sourcePath, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
+        if (!is_dir($sourcePath)) {
+            return;
+        }
 
-        foreach ($iterator as $item) {
-            if (!$item->isDir()) {
-                continue;
-            }
+        try {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($sourcePath, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
 
-            $directoryName = $item->getFilename();
-            if ($directoryName === '_tmp') {
-                $directoriesToRemove[] = $item->getPathname();
+            foreach ($iterator as $item) {
+                if (!$item->isDir()) {
+                    continue;
+                }
+
+                $directoryName = $item->getFilename();
+                if ($directoryName === '_tmp') {
+                    $directoriesToRemove[] = $item->getPathname();
+                }
             }
+        } catch (\Exception $e) {
+            // Ignore errors during iteration (directory may have been deleted)
         }
 
         foreach ($directoriesToRemove as $directoryPath) {
@@ -59,27 +67,37 @@ class RemoveTranslationFiles
 
     private function removeTranslatedFiles(string $sourcePath): void
     {
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($sourcePath, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::LEAVES_ONLY
-        );
+        if (!is_dir($sourcePath)) {
+            return;
+        }
 
-        foreach ($iterator as $item) {
-            if (!$item->isFile()) {
-                continue;
-            }
+        try {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($sourcePath, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            );
 
-            if (!str_contains($item->getPathname(), DIRECTORY_SEPARATOR . '_tmp' . DIRECTORY_SEPARATOR)) {
-                continue;
-            }
+            foreach ($iterator as $item) {
+                if (!$item->isFile()) {
+                    continue;
+                }
 
-            $filename = $item->getFilename();
-            foreach ($this->langs as $lang) {
-                if (str_starts_with($filename, $lang . '_')) {
-                    $this->filesystem->delete($item->getPathname());
-                    break;
+                if (!str_contains($item->getPathname(), DIRECTORY_SEPARATOR . '_tmp' . DIRECTORY_SEPARATOR)) {
+                    continue;
+                }
+
+                $filename = $item->getFilename();
+                foreach ($this->langs as $lang) {
+                    if (str_starts_with($filename, $lang . '_')) {
+                        if (file_exists($item->getPathname())) {
+                            $this->filesystem->delete($item->getPathname());
+                        }
+                        break;
+                    }
                 }
             }
+        } catch (\Exception $e) {
+            // Ignore errors during iteration (directory may have been deleted)
         }
     }
 }

--- a/listeners/TranslateContent.php
+++ b/listeners/TranslateContent.php
@@ -53,7 +53,6 @@ class TranslateContent
     {
         $this->jigsaw->app->events->afterBuild([
             PersistExtractedStrings::class,
-            RemoveTranslationFiles::class,
         ]);
     }
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -29,5 +29,16 @@ mix.jigsaw()
     .version();
 
 mix.override((webpackConfig) => {
+    // In containerized environments, filesystem events are unreliable.
+    // Polling keeps `mix watch` alive instead of exiting after the first build.
+    if (process.env.HOST_UID || process.env.DOCKER || process.env.CI) {
+        webpackConfig.watchOptions = {
+            ...(webpackConfig.watchOptions || {}),
+            poll: 1000,
+            aggregateTimeout: 300,
+            ignored: /node_modules/,
+        };
+    }
+
     webpackConfig.plugins = webpackConfig.plugins.filter((plugin) => plugin.constructor.name !== 'WebpackBarPlugin');
 });


### PR DESCRIPTION
## Summary
- normalize `SERVER_MODE` handling in php entrypoint while keeping non-`watch` modes on serve flow
- bake php development defaults into image (`.docker/php/dev.ini`) via Dockerfile
- harden translation cleanup/listener behavior and memory-related handling in translation preparation
- improve webpack watch stability for containerized environments

## Notes
- `docker-compose.yml` was intentionally left out of these commits per request
- commits were created one file at a time with DCO sign-off (`git commit -s`)