### PR TITLE
Fix locale recursion in translation file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,7 @@ npm-debug.log
 /source/assets/sitemap.xml
 /source/[a-z][a-z]/
 /source/[a-z][a-z]-[A-Z][A-Z]/
-/source/_posts/_tmp/
 /source/_posts/_translated_tmp/
-/source/_stale_generated_translations/
 /source/_redirect/
 /source/_team/
 # Optional ignores

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ npm-debug.log
 /source/[a-z][a-z]/
 /source/[a-z][a-z]-[A-Z][A-Z]/
 /source/_posts/_tmp/
+/source/_posts/_translated_tmp/
+/source/_stale_generated_translations/
 /source/_redirect/
 /source/_team/
 # Optional ignores

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Listeners\RemoveTranslationFiles;
 use App\Listeners\TranslateContent;
 use ElaborateCode\JigsawLocalization\LoadLocalization;
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Listeners\RemoveTranslationFiles;
 use App\Listeners\TranslateContent;
 use ElaborateCode\JigsawLocalization\LoadLocalization;
 

--- a/config.php
+++ b/config.php
@@ -124,7 +124,7 @@ return [
     'getFromCategory' => function($page, $category) {
         $files = array_merge(
             glob('source/_posts/*'),
-            glob('source/_posts/_tmp/*'),
+            glob('source/_posts/' . \App\Listeners\PrepareTranslationFiles::TEMP_DIRECTORY_NAME . '/*'),
         );
         $parser = new Parser(
             markdownParser: new MarkdownParser()

--- a/listeners/AddNewTranslation.php
+++ b/listeners/AddNewTranslation.php
@@ -65,9 +65,15 @@ class AddNewTranslation
             mkdir('lang/' . $defaultLocale, 0755, true);
         }
 
+        $encoded = json_encode($updated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL;
+
+        if (is_file($translationFile) && file_get_contents($translationFile) === $encoded) {
+            return;
+        }
+
         file_put_contents(
             $translationFile,
-            json_encode($updated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . PHP_EOL
+            $encoded
         );
     }
 

--- a/listeners/PrepareTranslationFiles.php
+++ b/listeners/PrepareTranslationFiles.php
@@ -43,15 +43,16 @@ class PrepareTranslationFiles
                 if (str_starts_with($file->getRelativePathname(), '_')) {
                     return false;
                 }
+                if ($this->isInsideLocaleDirectory($file->getRelativePathname())) {
+                    return false;
+                }
                 if (!in_array($file->getExtension(), ['markdown', 'md', 'mdown'])
                     && !Str::contains($file->getFilename(), '.blade.')
                 ) {
                     return false;
                 }
-                foreach ($this->langs as $lang) {
-                    if (Str::startsWith($file->getFilename(), $lang . '_')) {
-                        return false;
-                    }
+                if ($this->hasLocaleFilenamePrefix($file->getFilename())) {
+                    return false;
                 }
                 return true;
             })
@@ -72,10 +73,8 @@ class PrepareTranslationFiles
             $self = $this;
             collect($this->filesystem->files($path))
                 ->filter(function ($file) {
-                    foreach ($this->langs as $lang) {
-                        if (Str::startsWith($file->getFilename(), $lang . '_')) {
-                            return false;
-                        }
+                    if ($this->hasLocaleFilenamePrefix($file->getFilename())) {
+                        return false;
                     }
                     return true;
                 })
@@ -179,5 +178,34 @@ class PrepareTranslationFiles
         );
         $relativePath = explode('/', $relativePath);
         return substr($relativePath[0], 1);
+    }
+
+    private function isInsideLocaleDirectory(string $relativePathname): bool
+    {
+        $normalizedPath = str_replace('\\', '/', ltrim($relativePathname, '/'));
+
+        // Only inspect directory segments (not the filename) and ignore files that
+        // are already inside any locale folder at any depth.
+        $segments = explode('/', $normalizedPath);
+        array_pop($segments);
+
+        foreach ($segments as $segment) {
+            if (in_array($segment, $this->langs, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasLocaleFilenamePrefix(string $filename): bool
+    {
+        foreach ($this->langs as $lang) {
+            if (Str::startsWith($filename, $lang . '_')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/listeners/PrepareTranslationFiles.php
+++ b/listeners/PrepareTranslationFiles.php
@@ -12,6 +12,8 @@ use TightenCo\Jigsaw\Parsers\MarkdownParser;
 
 class PrepareTranslationFiles
 {
+    public const TEMP_DIRECTORY_NAME = '_translated_tmp';
+
     private Jigsaw $jigsaw;
     private Filesystem $filesystem;
     private FrontMatterParser $frontMatterParser;
@@ -108,7 +110,7 @@ class PrepareTranslationFiles
                 }
             }
             if ($isCollection) {
-                $translatedName = '_tmp/'.$lang . '_' . $translatedName;
+                $translatedName = self::TEMP_DIRECTORY_NAME . '/' . $lang . '_' . $translatedName;
             } else {
                 $translatedName = $lang . '/' . $translatedName;
             }

--- a/listeners/PrepareTranslationFiles.php
+++ b/listeners/PrepareTranslationFiles.php
@@ -136,11 +136,26 @@ class PrepareTranslationFiles
         $this->filesystem->ensureDirectoryExists(
             pathinfo($destinationPath, PATHINFO_DIRNAME)
         );
-        $this->filesystem->copy(
-            $file->getPathName(),
-            $destinationPath
-        );
+        if ($this->shouldCopyFile($file->getPathName(), $destinationPath)) {
+            $this->filesystem->copy(
+                $file->getPathName(),
+                $destinationPath
+            );
+        }
         $this->items[] = new SplFileInfo($destinationPath);
+    }
+
+    private function shouldCopyFile(string $sourcePath, string $destinationPath): bool
+    {
+        if (!is_file($destinationPath)) {
+            return true;
+        }
+
+        if (filesize($sourcePath) !== filesize($destinationPath)) {
+            return true;
+        }
+
+        return hash_file('sha256', $sourcePath) !== hash_file('sha256', $destinationPath);
     }
 
     private function translateFilename(SplFileInfo $file, $translated): string

--- a/listeners/RemoveTranslationFiles.php
+++ b/listeners/RemoveTranslationFiles.php
@@ -50,12 +50,12 @@ class RemoveTranslationFiles
                 }
 
                 $directoryName = $item->getFilename();
-                if ($directoryName === '_tmp') {
+                if ($directoryName === PrepareTranslationFiles::TEMP_DIRECTORY_NAME) {
                     $directoriesToRemove[] = $item->getPathname();
                 }
             }
-        } catch (\Exception $e) {
-            // Ignore errors during iteration (directory may have been deleted)
+        } catch (\UnexpectedValueException $e) {
+            // Ignore unreadable directories; best-effort cleanup continues below.
         }
 
         foreach ($directoriesToRemove as $directoryPath) {
@@ -82,7 +82,9 @@ class RemoveTranslationFiles
                     continue;
                 }
 
-                if (!str_contains($item->getPathname(), DIRECTORY_SEPARATOR . '_tmp' . DIRECTORY_SEPARATOR)) {
+                $isCurrentTempFile = str_contains($item->getPathname(), DIRECTORY_SEPARATOR . PrepareTranslationFiles::TEMP_DIRECTORY_NAME . DIRECTORY_SEPARATOR);
+
+                if (!$isCurrentTempFile) {
                     continue;
                 }
 
@@ -96,8 +98,8 @@ class RemoveTranslationFiles
                     }
                 }
             }
-        } catch (\Exception $e) {
-            // Ignore errors during iteration (directory may have been deleted)
+        } catch (\UnexpectedValueException $e) {
+            // Ignore unreadable directories during best-effort cleanup.
         }
     }
 }

--- a/listeners/TranslateContent.php
+++ b/listeners/TranslateContent.php
@@ -13,6 +13,7 @@ class TranslateContent
     public function handle(Jigsaw $jigsaw): void
     {
         $this->jigsaw = $jigsaw;
+        $this->cleanupGeneratedArtifacts();
         $this->registerTranslateContentHandler();
         $this->addTranslateFunction();
         $this->addPrepareTranslationFilesHandler();
@@ -63,6 +64,11 @@ class TranslateContent
         register_shutdown_function(static function () use ($jigsaw): void {
             (new RemoveTranslationFiles())->handle($jigsaw);
         });
+    }
+
+    private function cleanupGeneratedArtifacts(): void
+    {
+        (new RemoveTranslationFiles())->handle($this->jigsaw);
     }
 
     private function getSiteBuilder(): SiteBuilder


### PR DESCRIPTION
## Summary
- prevent recursive locale folder generation in `source` by ignoring files inside locale directories at any depth
- extract filename locale-prefix filtering into a dedicated method for readability and reuse
- include related updates in translation listeners and bootstrap adjustments present in the working tree

## Problem
Locale folders like `source/cs/cs/cs` could be created recursively when translation preparation re-processed files already inside locale directories.

## Fix
- update locale directory detection to inspect directory path segments and ignore any file located under a locale-named directory
- keep filename prefix filtering (`<lang>_`) and centralize it in one helper method

## Validation
- `php -l listeners/PrepareTranslationFiles.php`