### PR TITLE
Fix Docker Compose cache and runtime user handling

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -39,6 +39,7 @@ RUN echo "alias jigsaw=./vendor/bin/jigsaw" >> /etc/bash.bashrc && \
     /bin/bash -c "source /etc/bash.bashrc"
 
 WORKDIR /var/www/html
+USER www-data
 
 COPY entrypoint.sh /var/www/scripts/
 ENTRYPOINT [ "bash", "/var/www/scripts/entrypoint.sh" ]

--- a/.docker/php/entrypoint.sh
+++ b/.docker/php/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Set uid of host machine
-usermod --non-unique --uid "${HOST_UID}" www-data
-groupmod --non-unique --gid "${HOST_GID}" www-data
-
 if [[ ! -d "vendor" ]]; then
     composer i
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,15 +14,17 @@ services:
     # build:
     #   context: .docker/php
     restart: unless-stopped
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "127.0.0.1:${HTTP_PORT_BROWSERSYNC:-3000}:3000"
     volumes:
       - .:/var/www/html
-      - ~/.composer:/var/www/.composer/
-      - ~/.npm:/var/www/.npm/
+      - ${COMPOSER_CACHE_DIR:-${HOME}/.composer}:/var/www/.composer/
+      - ${NPM_CACHE_DIR:-${HOME}/.npm}:/var/www/.npm/
+    working_dir: /var/www/html
     environment:
-      - HOST_UID=${HOST_UID:-1000}
-      - HOST_GID=${HOST_GID:-1000}
+      - COMPOSER_HOME=/var/www/.composer
+      - NPM_CONFIG_CACHE=/var/www/.npm
       - SERVER_MODE=${SERVER_MODE:-watch}
       - TZ=${TZ:-America/Sao_Paulo}
       - XDEBUG_CONFIG=${XDEBUG_CONFIG:-client_host=172.17.0.1 start_with_request=yes}


### PR DESCRIPTION
## Summary

This PR makes the local PHP container runtime consistent with the Docker Compose configuration.

## What changed

- run the `php` service with the host `UID:GID`
- use configurable Composer and npm cache bind mounts
- set explicit Composer and npm cache environment variables used at runtime
- remove the entrypoint user/group remapping logic that conflicted with non-root execution
- keep the PHP image configured to run as `www-data`

## Validation

- rendered the effective `docker compose config`
- verified the edited files have no syntax errors
- created one signed commit per changed file
