### PR TITLE
Fix PR preview links by waiting for Pages deployment

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,5 +39,6 @@ jobs:
           pages-base-url: libresign.github.io/site-preview
           deploy-repository: LibreSign/site-preview
           preview-branch: main
+          wait-for-pages-deployment: true
           token: ${{ secrets.PREVIEW_TOKEN }}
           comment: ${{ github.event.pull_request.user.type != 'Bot' }}


### PR DESCRIPTION
## Summary

This PR fixes temporary 404 responses on PR preview links.

## Root cause

The preview workflow was posting the PR preview comment before GitHub Pages finished publishing the updated content in `LibreSign/site-preview`.

## What changed

- enabled `wait-for-pages-deployment: true` in `.github/workflows/preview.yml`

## Validation

- confirmed the previous preview URL eventually becomes available after Pages finishes deployment
- confirmed the previous workflow completed before the Pages deployment reached `success`
- this change makes the preview action wait before posting the preview link comment
