### PR TITLE
Fix non-root Composer home handling in Docker

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -34,9 +34,13 @@ RUN export NVM_DIR="/usr/local/nvm" \
     && echo 'export NVM_DIR="/usr/local/nvm"' > /etc/profile.d/nvm.sh \
     && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/profile.d/nvm.sh
 
-RUN echo "alias jigsaw=./vendor/bin/jigsaw" >> /etc/bash.bashrc && \
-    echo "alias compile='./vendor/bin/jigsaw build'" >> /etc/bash.bashrc && \
-    /bin/bash -c "source /etc/bash.bashrc"
+RUN cat <<'EOF' >> /etc/bash.bashrc
+alias jigsaw=./vendor/bin/jigsaw
+alias compile='./vendor/bin/jigsaw build'
+if ! getent passwd "$(id -u)" >/dev/null 2>&1; then
+    PS1='container:\w\$ '
+fi
+EOF
 
 WORKDIR /var/www/html
 USER www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "127.0.0.1:${HTTP_PORT_BROWSERSYNC:-3000}:3000"
     volumes:
       - .:/var/www/html
-      - ${COMPOSER_CACHE_DIR:-${HOME}/.composer}:/var/www/.composer/
+      - ${COMPOSER_HOME_DIR:-${HOME}/.composer}:/var/www/.composer/
       - ${NPM_CACHE_DIR:-${HOME}/.npm}:/var/www/.npm/
     working_dir: /var/www/html
     environment:


### PR DESCRIPTION
## Summary

This PR keeps the local PHP container running as the host UID/GID while restoring full Composer home access.

## What changed

- mount the full Composer home into `/var/www/.composer` again so Composer config and auth files remain available inside the container
- keep the Docker Compose PHP service non-root by running it as `${UID}:${GID}`
- add a shell prompt fallback in the PHP image for numeric UIDs that are not present in `/etc/passwd`

## Validation

- rendered `docker compose config`
- recreated the `php` service locally
- confirmed Composer sees `/var/www/.composer` as its home
- confirmed `config.json` and `auth.json` are readable from inside the container
- created one signed commit per changed file
