### PR TITLE
Fix HOME for non-root PHP shell in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ${NPM_CACHE_DIR:-${HOME}/.npm}:/var/www/.npm/
     working_dir: /var/www/html
     environment:
+      - HOME=/var/www/html
       - COMPOSER_HOME=/var/www/.composer
       - NPM_CONFIG_CACHE=/var/www/.npm
       - SERVER_MODE=${SERVER_MODE:-watch}


### PR DESCRIPTION
## Summary

This PR sets the `HOME` environment variable for the local non-root PHP container shell.

## What changed

- set `HOME=/var/www/html` in the `php` service environment

## Why

When the container runs as the host UID/GID, `HOME` was resolving to `/`, which caused `cd ~/` to jump to the filesystem root instead of the project working directory.

## Validation

- rendered `docker compose config`
- confirmed the resolved configuration contains `HOME: /var/www/html`
- verified the Compose file has no errors
