### PR TITLE
fix: add DCO sign-off to translation sync workflow

### DIFF
--- a/.github/workflows/translation-source-sync.yml
+++ b/.github/workflows/translation-source-sync.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Create pull request with source string updates
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore(i18n): refresh source strings"
+          commit-message: |
+            chore(i18n): refresh source strings
+            
+            Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
           title: "chore(i18n): refresh source strings"
           body: |
             Automated update of source strings for Weblate synchronization.


### PR DESCRIPTION
## Problem
The `translation-source-sync` GitHub workflow was creating pull requests without DCO (Developer Certificate of Origin) sign-off, causing all automatically-generated translation PRs to fail the DCO check.

This was evident in PR #382, where the commit lacked the required `Signed-off-by` trailer.

## Solution
Modified the workflow to include DCO sign-off in the commit message by:
- Adding the `Signed-off-by` trailer directly to the commit message
- Configuring proper committer and author information for the bot

## Changes
- Updated `.github/workflows/translation-source-sync.yml` to add DCO sign-off to commits created by `peter-evans/create-pull-request@v6`

This ensures all future translation sync PRs will pass the DCO check automatically.