### PR TITLE
fix: update lineicons icon names after upgrade to v1.3

### DIFF
--- a/source/_layouts/footer.blade.php
+++ b/source/_layouts/footer.blade.php
@@ -25,22 +25,22 @@
                         <ul class="ud-widget-socials">
                             <li>
                                 <a target="_blank" href="https://github.com/LibreSign/libresign" title="{{ $page->t("LibreSign GitHub repository")}}">
-                                    <i class="lni lni-github-original"></i>
+                                    <i class="lni lni-github"></i>
                                 </a>
                             </li>
                             <li>
                                 <a target="_blank" href="https://www.linkedin.com/company/libresign/" title="{{ $page->t("LibreSign LinkedIn page")}}">
-                                    <i class="lni lni-linkedin-original"></i>
+                                    <i class="lni lni-linkedin"></i>
                                 </a>
                             </li>
                             <li>
                               <a target="_blank" href="https://t.me/LibreSign" title="{{ $page->t("LibreSign Telegram group")}}">
-                                  <i class="lni lni-telegram-original"></i>
+                                  <i class="lni lni-telegram"></i>
                               </a>
                           </li>
                           <li>
                             <a target="_blank" href="https://www.instagram.com/libresign/" title="{{ $page->t("LibreSign Instagram profile")}}">
-                                <i class="lni lni-instagram-original"></i>
+                                <i class="lni lni-instagram"></i>
                             </a>
                         </li>
                         </ul>

--- a/source/_layouts/post_base.blade.php
+++ b/source/_layouts/post_base.blade.php
@@ -49,7 +49,7 @@
                         @php
                           Carbon\Carbon::setLocale(current_path_locale($page))
                         @endphp
-                        <i class="lni lni-calendar"></i> <span>{{ Carbon\Carbon::parse($page->date)->isoFormat('ll') }}</span>
+                        <i class="lni lni-calendar-days"></i> <span>{{ Carbon\Carbon::parse($page->date)->isoFormat('ll') }}</span>
                       </p>
                     </div>
                   </div>

--- a/source/_layouts/team-member.blade.php
+++ b/source/_layouts/team-member.blade.php
@@ -51,7 +51,7 @@
                   @foreach($page->social as $name => $url)
                   <li>
                     <a href="{{ $url }}">
-                      <i class="lni lni-{{ $name }}-original"></i>
+                      <i class="lni lni-{{ $name }}"></i>
                     </a>
                   </li>
                   @endforeach

--- a/source/_partials/testimonial_card.blade.php
+++ b/source/_partials/testimonial_card.blade.php
@@ -7,18 +7,18 @@
         @foreach($page->testimonials as $itens => $topics)
             <div class="testimonial-card">
                 <div class="testimonial_color_stars">
-                    <i class="lni lni-star-fill"></i>
-                    <i class="lni lni-star-fill"></i>
-                    <i class="lni lni-star-fill"></i>
-                    <i class="lni lni-star-fill"></i>
-                    <i class="lni lni-star-fill"></i>
-                </div>           
+                    <i class="lni lni-star-fat"></i>
+                    <i class="lni lni-star-fat"></i>
+                    <i class="lni lni-star-fat"></i>
+                    <i class="lni lni-star-fat"></i>
+                    <i class="lni lni-star-fat"></i>
+                </div>
                 <div class="testimonial-info">
                     <p class="text-justify">{{ $page->t($topics->comment) }}</p>
                     <h6 class="testimonial-brand">{{ $topics->author }}</h6>
                 </div>
             </div>
-        @endforeach       
+        @endforeach
     </div>
 </section>
 

--- a/source/_posts/advanced-security.md
+++ b/source/_posts/advanced-security.md
@@ -5,7 +5,7 @@ author: Daiane Alves
 date: 2024-06-27
 description: Keep your documents secure with end-to-end encryption and multi-factor authentication, ensuring protection throughout the electronic document signing process.
 categories: [features]
-icon: lock
+icon: locked-1
 ---
 
 ### Advanced security for public companies

--- a/source/_posts/api-documentation.md
+++ b/source/_posts/api-documentation.md
@@ -5,7 +5,7 @@ author: Vitor Mattos
 date: 2024-10-10
 description: Provides a practical guide on how to use the LibreSign API, including querying endpoints and understanding usage flows by observing requests in the application.
 categories: [features]
-icon: dashboard
+icon: dashboard-square-1
 ---
 
 # LibreSign API: Endpoints and usage flows

--- a/source/_posts/crl-implementation.md
+++ b/source/_posts/crl-implementation.md
@@ -5,7 +5,7 @@ author: Vitor Mattos
 date: 2025-12-22
 description: Learn how the Certificate Revocation List (CRL) implementation in LibreSign enhances digital signature security and ensures compliance with international best practices.
 categories: [features, security]
-icon: shield-check
+icon: shield-2-check
 ---
 
 ### CRL (Certificate Revocation List) Implementation in LibreSign

--- a/source/_posts/docmdp.md
+++ b/source/_posts/docmdp.md
@@ -5,7 +5,7 @@ author: Vitor Mattos
 date: 2025-12-22
 description: Learn how LibreSign implements DocMDP support according to ISO 32000 standards, providing document protection policies that ensure integrity and control over modifications after digital signature.
 categories: [features, security]
-icon: shield-check
+icon: shield-2-check
 ---
 
 ## DocMDP in LibreSign

--- a/source/_posts/document-management-education.md
+++ b/source/_posts/document-management-education.md
@@ -4,7 +4,7 @@ title: Document management in education - Challenges and solutions with LibreSig
 author: Daiane Alves
 date: 2024-05-07
 description: Document management in the educational field is complex and inefficient when done manually. With LibreSign, educational institutions can optimize document management, making it faster, more accurate, and efficient.
-icon: write
+icon: pen-to-square
 ---
 
 

--- a/source/_posts/electronic-signatures.md
+++ b/source/_posts/electronic-signatures.md
@@ -4,7 +4,7 @@ title: Free and open source software for electronic signatures
 author: Daiane Alves
 date: 2024-01-04
 description: Agility and security are paramount in business transactions, and LibreSign emerges as the intelligent choice for diverse sectors. Developed by LibreCode, a cooperative of IT professionals, LibreSign embodies the Free and Open-Source Software (FOSS) philosophy. With robust security standards, it ensures the inviolability of electronic signatures, making it ideal for government, education, and corporate enterprises
-icon: write
+icon: pen-to-square
 ---
 
 Agility and security in business transactions are essential for the success of any company. It is in this scenario that LibreSign stands out as the smart choice for businesses across various sectors, offering not only efficiency but also a commitment to security and privacy.

--- a/source/_posts/envelopes.blade.md
+++ b/source/_posts/envelopes.blade.md
@@ -5,7 +5,7 @@ author: Vitor Mattos
 date: 2025-12-30
 description: LibreSign now supports envelopes, allowing multiple documents to be grouped and signed as a single signing process with shared signers and unified progress tracking.
 categories: [features]
-icon: folder
+icon: folder-1
 ---
 
 ### Envelopes: Batch document signing in LibreSign

--- a/source/_posts/hybrid-signatures.md
+++ b/source/_posts/hybrid-signatures.md
@@ -5,7 +5,7 @@ author: Daiane Alves
 date: 2024-01-12
 description: Hybrid signatures streamline negotiation processes, offering flexibility in choosing between personal or system-generated digital certificates for signing documents digitally with LibreSign
 categories: [features]
-icon: files
+icon: file-multiple
 ---
 In the face of common challenges in digital signature processes, hybrid signatures present an effective solution. As a pioneer in this innovation, LibreSign provides its users with the flexibility to choose between using their personal digital certificate (e-CPF or e-CNPJ) or the system-generated certificate to sign documents from anywhere in the world.
 The digital certificate, whether e-CPF or e-CNPJ, plays a fundamental role in electronic signatures. Acquired through a Certification Authority, it serves as an electronic identity that validates documents and the identity of the holder. Stored on devices like tokens, smart cards, or in the cloud, the certificate is essential for ensuring legitimacy in digital signatures.

--- a/source/_posts/legal-validity-signatures.md
+++ b/source/_posts/legal-validity-signatures.md
@@ -4,7 +4,7 @@ title: Legal validity of electronic signatures in Brazil and around the world
 author: Daiane Alves
 date: 2024-06-18
 description: Discover the validity of digital signatures in Brazil and around the world. This article explores the legal basis of electronic signatures, citing specific laws and highlighting the benefits of this technology for businesses and institutions.
-icon: gift
+icon: box-gift-1
 ---
 
 ### Validity of Legal Signatures in Brazil and Around the World

--- a/source/_posts/multiple-signers.md
+++ b/source/_posts/multiple-signers.md
@@ -4,7 +4,7 @@ title: Multiple signers
 author: Daiane Alves
 date: 2024-01-04
 description: Streamline the signing of digital documents for multiple individuals, ensuring legal validity, security, and collaboration. Expedite contract processes between departments, eliminating the need for in-person meetings. Embrace efficiency and collaboration with LibreSign, guiding your organization towards seamless digital transformation
-icon: pencil
+icon: pencil-1
 ---
 
 With the evolution of commercial and legal demands, the need to allow a digital document to be signed by multiple individuals stands out. This capability not only speeds up workflow, ensures legal validity, and fosters collaboration among various stakeholders but also enables all involved parties to view and sign as needed, regardless of location or time zone.

--- a/source/_posts/qr-code.md
+++ b/source/_posts/qr-code.md
@@ -5,7 +5,7 @@ author: Daiane Alves
 date: 2024-01-22
 description: LibreSign revolutionizes document authenticity verification with QR Code, ensuring security, efficiency, and practicality. Its instantaneous validation, agility, transparency, and compatibility with various platforms make it perfect for sustainable businesses. Try this solution now!
 categories: [features]
-icon: full-screen
+icon: expand-square-4
 ---
 
 In the digital era, ensuring security and efficiency in document validation is crucial. LibreSign, a leader in digital signature innovation, redefines the experience by introducing document validation through QR Code. This article will discuss how this functionality not only reinforces security but also provides greater agility in verifying digitally signed documents.

--- a/source/_posts/real-time-monitoring.md
+++ b/source/_posts/real-time-monitoring.md
@@ -5,7 +5,7 @@ author: Daiane Alves
 date: 2024-06-27
 description: Transform document management in public organizations with LibreSign, monitoring signatures in real time, sending automatic reminders and optimizing your team's efficiency. Try our solution for transparent and productive administration.
 categories: [features]
-icon: dashboard
+icon: dashboard-square-1
 ---
 
 ### Real-time monitoring - Transform document management in public organizations with LibreSign

--- a/source/_posts/signature-order.blade.md
+++ b/source/_posts/signature-order.blade.md
@@ -5,7 +5,7 @@ author: Vitor Mattos
 date: 2025-12-22
 description: LibreSign now supports signature order control, allowing documents to be signed sequentially or in parallel. Administrators can define the default workflow while maintaining flexibility for approval processes and compliance requirements.
 categories: [features]
-icon: dashboard
+icon: dashboard-square-1
 ---
 
 ### Signature Order: Sequential or Parallel Signing in LibreSign

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -165,7 +165,7 @@
                 <div class="col-lg-6 mb-2 d-flex justify-content-center">
                   <div class="card" style="width: 18rem;">
                     <div class="card-body">
-                      <h5 class="me-2 card-title"><i class="lni lni-protection"></i> {{ $page->t('Security') }}</h5>
+                      <h5 class="me-2 card-title"><i class="lni lni-shield-2"></i> {{ $page->t('Security') }}</h5>
                       <p class="card-text">{{ $page->t('Encrypted signatures that guarantee the integrity of your documents.') }}</p>
                     </div>
                   </div>
@@ -173,7 +173,7 @@
                 <div class="col-lg-6 mb-2 d-flex justify-content-center">
                   <div class="card" style="width: 18rem;">
                     <div class="card-body">
-                      <h5 class="card-title"><i class="lni lni-dashboard"></i> {{ $page->t('Speed') }}</h5>
+                      <h5 class="card-title"><i class="lni lni-dashboard-square-1"></i> {{ $page->t('Speed') }}</h5>
                       <p class="card-text">{{ $page->t('Sign and send documents in seconds, from anywhere in the world.') }}</p>
                     </div>
                   </div>
@@ -181,7 +181,7 @@
                 <div class="col-lg-6 d-flex justify-content-center">
                   <div class="card" style="width: 18rem;">
                     <div class="card-body">
-                      <h5 class="card-title"><i class="lni lni-sprout"></i> {{ $page->t('Sustainability') }}</h5>
+                      <h5 class="card-title"><i class="lni lni-leaf-1"></i> {{ $page->t('Sustainability') }}</h5>
                       <p class="card-text">{{ $page->t('Contribute to a greener world by eliminating the use of paper.') }}</p>
                     </div>
                   </div>

--- a/source/pricing.blade.php
+++ b/source/pricing.blade.php
@@ -100,7 +100,7 @@
                     <td>
                       @if (is_bool($planValue))
                         <span class="{{ $planValue ? 'text-success' : 'text-danger' }} fw-semibold">
-                          <i class="lni lni-{{ $planValue ? 'checkmark' : 'close' }}"></i>
+                          <i class="lni lni-{{ $planValue ? 'check' : 'xmark' }}"></i>
                           {{ $page->t($planValue ? 'Included' : 'Not included') }}
                         </span>
                       @elseif (is_string($planValue) && $planValue !== '')
@@ -139,7 +139,7 @@
         <div class="col-lg-5 mb-3">
           <div class="ud-single-info border border-secondary-subtle rounded-bottom-1 rounded-top-1 p-3 size-box-pricing">
             <div class="ud-info-icon mb-2">
-              <i class="lni lni-cog fs-1"></i>
+              <i class="lni lni-gear-1 fs-1"></i>
             </div>
             <div class="ud-info-meta">
               <h5 class="fs-4">API</h5>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -35,7 +35,7 @@ mix.jigsaw({
     ])
     .sass('source/_assets/scss/ud-styles.scss', 'css')
     .sass('source/_assets/css/main.scss', 'css')
-    .copy(lineiconsSource, 'source/assets/build/css/fonts')
+    .copy(lineiconsSource, 'source/assets/build/css')
     .options({
         processCssUrls: false,
     })


### PR DESCRIPTION
## Problem

After running `npm update`, the `lineicons` package was upgraded from `1.0.x` to `1.3.2`. This caused all icons to disappear because:

1. **Font path changed**: v1.3 uses content-hashed filenames with no subdirectory prefix (`url(d495aba62101f856c80f.eot)`), while v1.0 used `url(fonts/LineIcons.woff)`. Fonts were being copied to `css/fonts/` but the CSS was looking for them in `css/`.

2. **Icon class names renamed/removed**: Many icon classes were renamed in v1.3.

## Changes

### `webpack.mix.js`
- Fix font copy destination: `css/fonts/` → `css/` to match the relative URLs in `lineicons.css` v1.3

### Templates & layouts (`source/_layouts/`, `source/_partials/`, `source/`)

| Old name | New name |
|---|---|
| `lni-github-original` | `lni-github` |
| `lni-linkedin-original` | `lni-linkedin` |
| `lni-telegram-original` | `lni-telegram` |
| `lni-instagram-original` | `lni-instagram` |
| `lni-calendar` | `lni-calendar-days` |
| `lni-star-fill` | `lni-star-fat` |
| `lni-protection` | `lni-shield-2` |
| `lni-dashboard` | `lni-dashboard-square-1` |
| `lni-sprout` | `lni-leaf-1` |
| `lni-cog` | `lni-gear-1` |
| `lni-checkmark` | `lni-check` |
| `lni-close` | `lni-xmark` |

### Post frontmatter (`source/_posts/`)

| Old name | New name |
|---|---|
| `lock` | `locked-1` |
| `dashboard` | `dashboard-square-1` |
| `shield-check` | `shield-2-check` |
| `write` | `pen-to-square` |
| `folder` | `folder-1` |
| `files` | `file-multiple` |
| `gift` | `box-gift-1` |
| `pencil` | `pencil-1` |
| `full-screen` | `expand-square-4` |