### PR TITLE
refactor: unify design tokens and fix accessibility issues

### DIFF
--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -2,11 +2,12 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import 'animate.css';
 
 import AOS from 'aos';
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 AOS.init({
   duration: 800,
   easing: 'ease-in-out-quart',
   once: true,
-  disable: 'mobile'
+  disable: prefersReducedMotion || 'mobile'
 });
 
 (function () {
@@ -36,9 +37,11 @@ AOS.init({
       if (shouldShow) {
         backToTop.classList.add("visible");
         backToTop.setAttribute("aria-hidden", "false");
+        backToTop.removeAttribute("tabindex");
       } else {
         backToTop.classList.remove("visible");
         backToTop.setAttribute("aria-hidden", "true");
+        backToTop.setAttribute("tabindex", "-1");
       }
     }
 
@@ -46,9 +49,11 @@ AOS.init({
       if (shouldShow) {
         footerContact.classList.add("visible");
         footerContact.setAttribute("aria-hidden", "false");
+        footerContact.setAttribute("tabindex", "0");
       } else {
         footerContact.classList.remove("visible");
         footerContact.setAttribute("aria-hidden", "true");
+        footerContact.setAttribute("tabindex", "-1");
       }
     }
   }

--- a/source/_assets/scss/_about.scss
+++ b/source/_assets/scss/_about.scss
@@ -1,7 +1,7 @@
 @use "variables" as *;
 
 .ud-about-story {
-  background: #f7fafc;
+  background: var(--bg-light);
   padding: 96px 0;
 
   @media #{$xs, $sm} {
@@ -9,8 +9,8 @@
   }
 
   &__title {
-    color: #2d3748;
-    font-size: clamp(2.2rem, 4.1vw, 3.85rem);
+    color: var(--text-gray);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     letter-spacing: -0.02em;
     line-height: 1.14;
@@ -19,7 +19,7 @@
 
   &__text {
     p {
-      color: #4a5568;
+      color: var(--text-muted);
       font-size: 1.02rem;
       line-height: 1.8;
       margin-bottom: 20px;
@@ -38,8 +38,8 @@
 
   &__item {
     align-items: flex-start;
-    background: #fff;
-    border: 1px solid #ececec;
+    background: var(--white);
+    border: 1px solid var(--border-light);
     box-shadow: 0 10px 24px rgba(0, 0, 0, 0.06);
     display: grid;
     gap: 18px;
@@ -54,7 +54,7 @@
   }
 
   &__badge {
-    color: #2d3748;
+    color: var(--text-gray);
     font-size: clamp(1.75rem, 2.6vw, 2.4rem);
     font-weight: 800;
     line-height: 1;
@@ -63,7 +63,7 @@
 
   &__icon {
     align-items: center;
-    background: #d97706;
+    background: var(--accent-color);
     border-radius: 50%;
     display: flex;
     height: 92px;
@@ -87,7 +87,7 @@
 
   &__content {
     h3 {
-      color: #2d3748;
+      color: var(--text-gray);
       font-size: clamp(1.22rem, 1.8vw, 1.6rem);
       font-weight: 700;
       line-height: 1.28;
@@ -95,7 +95,7 @@
     }
 
     p {
-      color: #4a5568;
+      color: var(--text-muted);
       font-size: 0.98rem;
       line-height: 1.7;
       margin: 0;
@@ -104,7 +104,7 @@
 }
 
 .ud-about-values {
-  background: #2d3748;
+  background: var(--surface-dark);
   padding: 88px 0;
 
   @media #{$xs, $sm} {
@@ -112,8 +112,8 @@
   }
 
   &__title {
-    color: #fff;
-    font-size: clamp(2.1rem, 4vw, 3.6rem);
+    color: var(--white);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.16;
     margin-bottom: 52px;
@@ -124,11 +124,11 @@
     background: transparent;
     border: 0;
     box-shadow: none;
-    color: #fff;
+    color: var(--white);
     padding: 0;
 
     &__icon {
-      background: #d97706;
+      background: var(--accent-color);
       height: 110px;
       margin-bottom: 24px;
       width: 110px;
@@ -149,8 +149,8 @@
     }
 
     &__title {
-      color: #fff;
-      font-size: clamp(1.35rem, 2vw, 1.7rem);
+      color: var(--white);
+      font-size: var(--fs-h3-card);
       font-weight: 700;
     }
 
@@ -163,7 +163,7 @@
 }
 
 .ud-about-team {
-  background: #f7fafc;
+  background: var(--bg-light);
   padding: 94px 0;
 
   @media #{$xs, $sm} {
@@ -183,15 +183,15 @@
 
   &__content {
     h2 {
-      color: #2d3748;
-      font-size: clamp(2.05rem, 3.8vw, 3.35rem);
+      color: var(--text-gray);
+      font-size: var(--fs-h2-section);
       font-weight: 800;
       line-height: 1.15;
       margin-bottom: 16px;
     }
 
     > p {
-      color: #4a5568;
+      color: var(--text-muted);
       font-size: 1.02rem;
       line-height: 1.76;
       margin-bottom: 24px;
@@ -199,13 +199,13 @@
   }
 
   &__quote {
-    background: #fff;
-    border-left: 4px solid #d97706;
+    background: var(--white);
+    border-left: 4px solid var(--accent-color);
     margin: 0 0 30px;
     padding: 22px 22px 20px;
 
     p {
-      color: #2d3748;
+      color: var(--text-gray);
       font-size: 1.05rem;
       font-style: italic;
       line-height: 1.7;
@@ -214,14 +214,14 @@
 
     footer {
       strong {
-        color: #2d3748;
+        color: var(--text-gray);
         display: block;
         font-size: 1rem;
         font-weight: 700;
       }
 
       span {
-        color: #64748b;
+        color: var(--text-muted);
         display: block;
         font-size: 0.94rem;
         margin-top: 3px;
@@ -231,7 +231,7 @@
 }
 
 .ud-about-cta {
-  background: #2d3748;
+  background: var(--surface-dark);
   padding: 86px 0;
 
   @media #{$xs, $sm} {
@@ -239,8 +239,8 @@
   }
 
   h2 {
-    color: #fff;
-    font-size: clamp(2.1rem, 4vw, 3.5rem);
+    color: var(--white);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.15;
     margin-bottom: 16px;

--- a/source/_assets/scss/_blog-details.scss
+++ b/source/_assets/scss/_blog-details.scss
@@ -78,7 +78,7 @@
       font-weight: 500;
       font-size: 14px;
       line-height: 28px;
-      color: #ffffff;
+      color: var(--white);
     }
 
     a {
@@ -101,7 +101,7 @@
       font-weight: 500;
       font-size: 14px;
       line-height: 28px;
-      color: #ffffff;
+      color: var(--white);
       margin-right: 30px;
 
       &:last-child {
@@ -394,14 +394,16 @@
     }
 
     .ud-main-btn {
-      background: #13c296;
+      background: var(--amber);
+      color: var(--primary-color);
       box-shadow: 0px 4px 42px rgba(0, 0, 0, 0.01);
       border-radius: 5px;
       width: 100%;
       margin-bottom: 24px;
 
       &:hover {
-        background: var(--heading-color);
+        background: var(--amber-hover);
+        color: var(--primary-color);
       }
     }
 
@@ -437,7 +439,7 @@
   .ud-articles-list {
     li {
       padding: 20px 0;
-      border-bottom: 1px solid #f2f3f8;
+      border-bottom: 1px solid var(--border-light);
       display: flex;
       align-items: center;
 

--- a/source/_assets/scss/_button.scss
+++ b/source/_assets/scss/_button.scss
@@ -52,8 +52,8 @@
 
   &:hover,
   &:focus {
-    background: var(--heading-color);
-    border-color: var(--heading-color);
+    background: var(--primary-hover);
+    border-color: var(--primary-hover);
     color: var(--white);
   }
 }
@@ -62,14 +62,14 @@
 .ud-btn-solid-warm {
   @extend %ud-btn-base;
 
-  background: #d97706;
-  border: 1px solid #d97706;
+  background: var(--accent-color);
+  border: 1px solid var(--accent-color);
   color: var(--white);
 
   &:hover,
   &:focus {
-    background: #c56c04;
-    border-color: #c56c04;
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
     color: var(--white);
   }
 }
@@ -78,16 +78,15 @@
 .ud-btn-solid-amber {
   @extend %ud-btn-base;
 
-  background: #ffc107;
-  border: 1px solid #ffc107;
+  background: var(--amber);
+  border: 1px solid var(--amber);
   color: var(--primary-color);
 
   &:hover,
   &:focus {
-    background: #ffc107;
-    border-color: #ffc107;
+    background: var(--amber-hover);
+    border-color: var(--amber-hover);
     color: var(--primary-color);
-    filter: brightness(1.15);
   }
 }
 

--- a/source/_assets/scss/_card.scss
+++ b/source/_assets/scss/_card.scss
@@ -151,7 +151,7 @@
 // Usage: cardClass => 'ud-card--outlined'
 // ─────────────────────────────────────────────────────────────
 .ud-card--outlined {
-  border: 1px solid #ececec;
+  border: 1px solid var(--border-light);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.06);
   padding: 40px 34px 42px;
 
@@ -160,7 +160,7 @@
   }
 
   .ud-card__icon {
-    background: #d97706;
+    background: var(--accent-color);
     height: 240px;
     margin-bottom: 30px;
     width: 240px;
@@ -188,14 +188,14 @@
   }
 
   .ud-card__title {
-    color: #2d3748;
-    font-size: clamp(1.85rem, 2.2vw, 2.25rem);
+    color: var(--text-gray);
+    font-size: var(--fs-h3-card);
     font-weight: 700;
     line-height: 1.2;
   }
 
   .ud-card__body p {
-    color: #4a5568;
+    color: var(--text-muted);
     font-size: 1.02rem;
     line-height: 1.75;
   }
@@ -210,7 +210,7 @@
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 20px;
-  color: #fff;
+  color: var(--white);
   padding: 28px 26px 32px;
 
   .ud-card__header {
@@ -219,7 +219,7 @@
   }
 
   .ud-card__title {
-    color: #fff;
+    color: var(--white);
     font-size: 1.15rem;
     font-weight: 700;
   }
@@ -254,7 +254,7 @@
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 20px;
-  color: #fff;
+  color: var(--white);
   padding: 20px 20px 28px;
 
   .ud-card__header {
@@ -263,7 +263,7 @@
   }
 
   .ud-card__title {
-    color: #fff;
+    color: var(--white);
     font-size: 1.15rem;
     font-weight: 700;
   }
@@ -298,10 +298,10 @@
 // across every page-specific SCSS file.
 //
 // .ud-page-section       — light grey bg, standard inner-page section
-// .ud-page-section--dark — dark (#2d3748) bg, white text
+// .ud-page-section--dark — dark brand-teal bg, white text
 // ─────────────────────────────────────────────────────────────
 .ud-page-section {
-  background: #f7fafc;
+  background: var(--bg-light);
   padding: 96px 0;
 
   @media #{$xs, $sm} {
@@ -309,32 +309,28 @@
   }
 
   .ud-home-section__title {
-    color: #2d3748;
-    font-size: clamp(2.35rem, 4.2vw, 4rem);
+    color: var(--text-gray);
+    font-size: var(--fs-h2-section);
     line-height: 1.15;
     margin-bottom: 22px;
   }
 
   .ud-home-section__subtitle {
-    color: #4a5568;
+    color: var(--text-muted);
     font-size: 1.03rem;
     line-height: 1.72;
     margin-bottom: 56px;
   }
 
-  .ud-home-section__actions {
-    margin-top: 52px;
-  }
-
-  // Standard pill CTA — shape now from .ud-btn-primary via _button.scss
+  // Standard pill CTA — shape from the ud-btn system in _button.scss
   .ud-home-section__actions {
     margin-top: 52px;
   }
 }
 
 .ud-page-section--dark {
-  background: #2d3748;
-  color: #fff;
+  background: var(--surface-dark);
+  color: var(--white);
   padding: 88px 0;
 
   @media #{$xs, $sm} {
@@ -354,8 +350,8 @@
   }
 
   .ud-home-section__title {
-    color: #fff;
-    font-size: clamp(2.2rem, 4vw, 3.6rem);
+    color: var(--white);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.16;
     margin-bottom: 20px;

--- a/source/_assets/scss/_common.scss
+++ b/source/_assets/scss/_common.scss
@@ -14,13 +14,18 @@
   --font: "Montserrat", sans-serif;
 
   --primary-color: #184c4e;
-  --primary-dark: #13c296;
+  --primary-hover: #0f3739;
+  --primary-dark: #0b5f55;
+  --surface-dark: #123c40; // dark brand sections & heroes
   --secondary-color: #00a3be;
   --accent-color: #d97706;
+  --accent-hover: #b45309;
+  --amber: #ffc107;
+  --amber-hover: #ffb300;
 
-  --color-dark: #263238;
+  --color-dark: #263238; // header/footer chrome
   --heading-color: #212b36;
-  --body-color: #000000;
+  --body-color: #2d3748;
   --white: #ffffff;
   --text-light: #f5f5f5;
   --text-gray: #2d3748;
@@ -30,20 +35,50 @@
 
   --bg-light: #f7fafc;
   --bg-hover: rgba(0, 219, 255, 0.1);
+  --tint-teal: #e3efec; // soft brand tint for avatars/badges
 
-  --border-light: #d4deff;
+  --border-light: #e2e8f0;
   --border-footer: rgba(136, 144, 164, 0.43);
-  --border-input: #f1f1f1;
+  --border-input: #8b99a8;
 
-  --focus-color: #00dbff;
+  // Cyan is reserved for the focus ring on dark surfaces — never an accent.
+  --focus-color-light: #005e54;
+  --focus-color-dark: #00dbff;
+  --focus-color: var(--focus-color-light);
   --success-color: #2ecc71;
   --warning-color: #ffc107;
-  --star-color: #fbb040;
-  --error-color: #ff7d7d;
+  --star-color: #ffc107;
+  --error-color: #c62828;
 
   --color-gray: #afb2b5;
   --color-light-muted: #cdced6;
   --shadow-light: #ebeffd;
+
+  --fs-display: clamp(2.25rem, 4.5vw, 4rem); // page hero h1
+  --fs-h2-section: clamp(2rem, 3.4vw, 3rem); // section titles
+  --fs-h3-card: clamp(1.5rem, 2vw, 1.9rem); // card titles
+}
+
+.ud-header,
+.ud-footer,
+.ud-hero,
+.ud-page-banner,
+.ud-page-section--dark,
+.ud-home-cta,
+.back-to-top,
+#footer-contact,
+.ud-about-values,
+.ud-about-cta,
+.ud-features-cta,
+.ud-coop-dna,
+.ud-ps-process {
+  --focus-color: var(--focus-color-dark);
+}
+
+// White dropdowns floating over the dark header
+.ud-header .ud-nav-submenu,
+.ud-header .ud-submenu {
+  --focus-color: var(--focus-color-light);
 }
 
 body {
@@ -72,19 +107,23 @@ textarea {
 }
 
 a,
-a:focus,
-input:focus,
-textarea:focus,
-button:focus,
-.navbar-toggler:focus {
-  text-decoration: none;
-  outline: none;
-  box-shadow: none;
-}
-
-a:focus,
 a:hover {
   text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[tabindex]:focus-visible {
+  outline: 3px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
 }
 
 i,
@@ -115,10 +154,10 @@ h6 {
 }
 
 h1 {
-  font-size: 48px;
+  font-size: clamp(34px, 4vw, 48px);
 }
 h2 {
-  font-size: 36px;
+  font-size: clamp(28px, 3vw, 36px);
 }
 h3 {
   font-size: 28px;
@@ -156,6 +195,22 @@ p {
 }
 
 /*===== Accessibility =====*/
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  [data-aos] {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
 
 .visually-hidden {
   position: absolute !important;

--- a/source/_assets/scss/_company-solutions.scss
+++ b/source/_assets/scss/_company-solutions.scss
@@ -14,7 +14,7 @@
 }
 
 .ud-cs-testimonials {
-  background: #2d3748;
+  background: var(--surface-dark);
   padding: 88px 0;
 
   @media #{$xs, $sm} {
@@ -23,7 +23,7 @@
 
   &__title {
     color: #fff;
-    font-size: clamp(2.3rem, 4vw, 3.65rem);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.16;
     margin-bottom: 24px;

--- a/source/_assets/scss/_contact.scss
+++ b/source/_assets/scss/_contact.scss
@@ -134,7 +134,7 @@
 
 .ud-contact-sales {
   padding: 90px 0 86px;
-  background: #eceff1;
+  background: var(--bg-light);
 
   @media #{$xs, $sm} {
     padding: 60px 0;
@@ -164,7 +164,7 @@
     }
 
     .contact-subtitle {
-      color: #4a5568;
+      color: var(--text-muted);
       font-size: 1.125rem;
       line-height: 1.6;
       margin-bottom: 46px;
@@ -185,7 +185,7 @@
       margin: 0;
 
       li {
-        color: #2d3748;
+        color: var(--text-gray);
         font-size: 1.25rem;
         line-height: 1.55;
         margin-bottom: 20px;
@@ -194,7 +194,7 @@
 
         &:before {
           content: "●";
-          color: #d97706;
+          color: var(--accent-color);
           font-size: 0.7em;
           position: absolute;
           left: 0;
@@ -202,7 +202,7 @@
         }
 
         strong {
-          color: #2d3748;
+          color: var(--text-gray);
           font-weight: 700;
         }
       }
@@ -214,10 +214,10 @@
   }
 
   .contact-form-wrapper {
-    background: #efefef;
-    border: 1px solid #d4d4d4;
-    border-radius: 0;
-    box-shadow: none;
+    background: var(--white);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    box-shadow: 0 4px 28px rgba(0, 0, 0, 0.05);
     padding: 30px;
 
     @media #{$xs} {
@@ -235,7 +235,7 @@
       margin-bottom: 18px;
 
       label {
-        color: #475569;
+        color: var(--text-muted);
         font-size: 1rem;
         font-weight: 500;
         margin-bottom: 6px;
@@ -244,10 +244,10 @@
 
       input,
       textarea {
-        background: #d9d9d9;
-        border: 1px solid #d9d9d9;
-        border-radius: 0;
-        color: #2f3b51;
+        background: var(--white);
+        border: 1px solid var(--border-input);
+        border-radius: 8px;
+        color: var(--text-gray);
         font-size: 1.05rem;
         min-height: 56px;
         padding: 11px 18px;
@@ -259,9 +259,8 @@
         }
 
         &:focus {
-          background: #fff;
-          border-color: #c2c9d3;
-          box-shadow: 0 0 0 2px rgba(47, 59, 81, 0.08);
+          border-color: var(--primary-color);
+          box-shadow: 0 0 0 3px rgba(24, 76, 78, 0.15);
           outline: none;
         }
       }

--- a/source/_assets/scss/_cooperatives.scss
+++ b/source/_assets/scss/_cooperatives.scss
@@ -14,8 +14,8 @@
 }
 
 .ud-coop-dna {
-  background: #2d3748;
-  color: #fff;
+  background: var(--surface-dark);
+  color: var(--white);
   padding: 88px 0;
 
   @media #{$xs, $sm} {
@@ -34,8 +34,8 @@
   }
 
   &__title {
-    color: #fff;
-    font-size: clamp(2.2rem, 4vw, 3.55rem);
+    color: var(--white);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.16;
     margin-bottom: 20px;

--- a/source/_assets/scss/_features-page.scss
+++ b/source/_assets/scss/_features-page.scss
@@ -19,15 +19,15 @@
     text-decoration: none;
 
     &:hover {
-      color: var(--secondary-color);
+      color: var(--primary-hover);
       text-decoration: underline;
     }
   }
 }
 
 .ud-features-cta {
-  background: #2d3748;
-  color: #fff;
+  background: var(--surface-dark);
+  color: var(--white);
   padding: 88px 0;
 
   @media #{$xs, $sm} {
@@ -35,8 +35,8 @@
   }
 
   &__title {
-    color: #fff;
-    font-size: clamp(2.2rem, 4vw, 3.6rem);
+    color: var(--white);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.16;
     margin-bottom: 20px;

--- a/source/_assets/scss/_footer.scss
+++ b/source/_assets/scss/_footer.scss
@@ -7,8 +7,9 @@
   z-index: 1;
   overflow: hidden;
 
-  &>div {
-    margin-bottom: 200px;
+  & > div {
+    padding-top: 32px;
+    padding-bottom: 64px;
   }
 }
 
@@ -322,7 +323,7 @@
       }
 
       &:hover .social-icon {
-        color: var(--focus-color);
+        color: var(--amber);
       }
 
       &:focus {
@@ -360,14 +361,14 @@
       border-radius: 4px;
 
       &:hover {
-        color: var(--focus-color);
+        color: var(--amber);
         padding-left: 10px;
       }
 
       &:focus {
         outline: 3px solid var(--focus-color);
         outline-offset: 2px;
-        color: var(--focus-color);
+        color: var(--amber);
         padding-left: 8px;
       }
 
@@ -380,7 +381,7 @@
       &:focus-visible {
         outline: 3px solid var(--focus-color);
         outline-offset: 2px;
-        color: var(--focus-color);
+        color: var(--amber);
         padding-left: 8px;
       }
     }
@@ -440,7 +441,7 @@
       }
 
       &:hover {
-        color: var(--focus-color);
+        color: var(--amber);
       }
     }
   }
@@ -452,10 +453,12 @@
     color: var(--text-footer);
 
     a {
-      color: var(--primary-color);
+      color: var(--white);
+      text-decoration: underline;
+      text-underline-offset: 3px;
 
       &:hover {
-        text-decoration: underline;
+        color: var(--amber);
       }
     }
 

--- a/source/_assets/scss/_header.scss
+++ b/source/_assets/scss/_header.scss
@@ -7,8 +7,8 @@
   top: 0;
   z-index: 999;
   padding: 12px 24px;
-  background-color: var(--secondary-color);
-  color: var(--color-dark);
+  background-color: var(--amber);
+  color: var(--primary-color);
   font-weight: 600;
   text-decoration: none;
   border-radius: 0 0 8px 0;
@@ -140,14 +140,16 @@
       &.active:not(.link-button),
       &.show:not(.link-button) {
         color: var(--white);
-        opacity: 0.5;
+        opacity: 0.75;
+        text-decoration: underline;
+        text-underline-offset: 6px;
       }
     }
 
     &:hover {
       & > .nav-link:not(.link-button) {
         color: var(--white);
-        opacity: 0.5;
+        opacity: 0.75;
       }
     }
 
@@ -245,8 +247,8 @@
     }
 
     .link-button {
-      background-color: var(--secondary-color);
-      color: var(--color-dark);
+      background-color: var(--amber);
+      color: var(--primary-color);
       height: 38px;
       border-radius: 32px;
       font-weight: 600;
@@ -267,16 +269,8 @@
       }
 
       &:hover {
-        color: var(--color-dark);
-        filter: brightness(1.25);
-      }
-
-      &::after {
-        content: '';
-        position: absolute;
-        inset: 4px;
-        border: 1px solid var(--focus-color);
-        border-radius: 20px;
+        background-color: var(--amber-hover);
+        color: var(--primary-color);
       }
     }
   }
@@ -358,7 +352,7 @@
 
     &:hover,
     &.show {
-      opacity: 0.5;
+      opacity: 0.75;
     }
   }
 
@@ -393,7 +387,7 @@
       gap: 8px;
 
       &:focus {
-        outline: 2px solid var(--secondary-color);
+        outline: 2px solid var(--focus-color);
         outline-offset: 2px;
         border-radius: 4px;
       }

--- a/source/_assets/scss/_hero.scss
+++ b/source/_assets/scss/_hero.scss
@@ -6,7 +6,7 @@
   max-width: 1920px;
   margin-left: auto;
   margin-right: auto;
-  background-color: #123c40;
+  background-color: var(--surface-dark);
   background-image: none;
   background-repeat: no-repeat;
   background-size: cover;
@@ -138,7 +138,7 @@
     .ud-hero-title {
       color: var(--text-light);
       font-weight: bold;
-      font-size: clamp(36px, 5vw, 72px);
+      font-size: var(--fs-display);
       line-height: 1.22;
       margin-bottom: 30px;
       max-width: 680px;

--- a/source/_assets/scss/_main.scss
+++ b/source/_assets/scss/_main.scss
@@ -3,19 +3,7 @@
 @import "lineicons/dist/lineicons.css";
 @import "aos/dist/aos.css";
 
-/*cards target audience*/
-
 .card-title {
     color: var(--text-gray);
-}
-
-.main-cards {
-    background-color: var(--white);
-    padding: 32px 40px 48px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    background-color: var(--warning-color);
-    margin-bottom: 0.5rem;
 }
 

--- a/source/_assets/scss/_pricing.scss
+++ b/source/_assets/scss/_pricing.scss
@@ -51,7 +51,7 @@
   }
 
   .ud-pricing-tagline {
-    color: #4a5568;
+    color: var(--text-muted);
     font-size: 15px;
     line-height: 1.6;
     margin-bottom: 0;

--- a/source/_assets/scss/_public-sector.scss
+++ b/source/_assets/scss/_public-sector.scss
@@ -17,14 +17,14 @@
   }
 
   .ud-home-section__title {
-    color: #2d3748;
-    font-size: clamp(3rem, 5vw, 4.65rem);
+    color: var(--text-gray);
+    font-size: var(--fs-h2-section);
     letter-spacing: -0.03em;
     line-height: 1.12;
   }
 
   .ud-home-section__subtitle {
-    color: #4a5568;
+    color: var(--text-muted);
     font-size: 1rem;
     line-height: 1.7;
     margin-bottom: 56px;
@@ -40,11 +40,11 @@
   }
 
   .ud-card--outlined .ud-card__title {
-    font-size: clamp(2rem, 2.4vw, 2.25rem);
+    font-size: var(--fs-h3-card);
   }
 
   .ud-card--outlined .ud-card__icon {
-    background: #e67e00;
+    background: var(--accent-color);
     height: 340px;
     margin-bottom: 36px;
     width: 340px;
@@ -75,7 +75,7 @@
 }
 
 .ud-ps-process {
-  background: #2d3748;
+  background: var(--surface-dark);
   padding: 88px 0;
 
   @media #{$xs, $sm} {
@@ -84,7 +84,7 @@
 
   &__title {
     color: var(--white);
-    font-size: clamp(2.5rem, 4.5vw, 4.5rem);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     line-height: 1.15;
     margin-bottom: 28px;
@@ -147,7 +147,7 @@
 
   &__title {
     color: var(--white);
-    font-size: clamp(1.75rem, 2.4vw, 2.2rem);
+    font-size: var(--fs-h3-card);
     font-weight: 700;
     line-height: 1.18;
     margin-bottom: 24px;

--- a/source/_assets/scss/_team.scss
+++ b/source/_assets/scss/_team.scss
@@ -19,7 +19,7 @@
   }
 
   &__description {
-    color: #4b4b4b;
+    color: var(--text-muted);
     font-size: 18px;
     line-height: 1.75;
     margin: 0 auto;
@@ -53,7 +53,7 @@
 
   &__header {
     align-items: center;
-    background: linear-gradient(160deg, #e8f5e9 0%, #f1f8e9 100%);
+    background: linear-gradient(160deg, var(--tint-teal) 0%, #f2f8f6 100%);
     display: flex;
     justify-content: center;
     padding: 40px 24px 20px;
@@ -118,7 +118,7 @@
   }
 
   &__bio {
-    color: #4f4f4f;
+    color: var(--text-muted);
     font-size: 14.5px;
     line-height: 1.75;
     margin-bottom: 0;
@@ -194,7 +194,7 @@
   }
 
   &__avatar {
-    border: 5px solid #e8f5e9;
+    border: 5px solid var(--tint-teal);
     border-radius: 50%;
     box-shadow: 0 12px 36px rgba(0, 0, 0, 0.12);
     display: block;
@@ -239,7 +239,7 @@
   }
 
   &__bio {
-    color: #4b4b4b;
+    color: var(--text-muted);
     font-size: 16.5px;
     line-height: 1.85;
     margin-bottom: 32px;

--- a/source/_assets/scss/home/_benefits.scss
+++ b/source/_assets/scss/home/_benefits.scss
@@ -9,7 +9,7 @@
     }
 
     &__icon {
-      background-color: #f3f4fe;
+      background-color: var(--bg-light);
 
       img {
         height: 108px;
@@ -18,20 +18,6 @@
         @media #{$xs, $sm} {
           height: 84px;
           width: 84px;
-        }
-      }
-    }
-
-    &__actions {
-      .ud-main-btn {
-        background-color: transparent;
-        border: 2px solid var(--primary-color);
-        color: var(--primary-color);
-
-        &:hover {
-          background-color: rgba(24, 76, 78, 0.08);
-          border-color: var(--primary-color);
-          color: var(--primary-color);
         }
       }
     }

--- a/source/_assets/scss/home/_blog.scss
+++ b/source/_assets/scss/home/_blog.scss
@@ -10,14 +10,14 @@
 
   .ud-home-section__title {
     color: var(--ud-home-highlight-color);
-    font-size: clamp(2rem, 3vw, 3.5rem);
+    font-size: var(--fs-h2-section);
     font-weight: 800;
     letter-spacing: -0.03em;
     line-height: 1.12;
   }
 
   .ud-home-section__subtitle {
-    color: #4b4b4b;
+    color: var(--text-muted);
     font-size: 18px;
     line-height: 1.6;
     margin-bottom: 0;
@@ -74,7 +74,7 @@
 
   &__frame {
     aspect-ratio: 465 / 275;
-    background: #f3f6f8;
+    background: var(--bg-light);
     display: block;
     overflow: hidden;
 
@@ -94,7 +94,7 @@
 
   &__category {
     align-items: center;
-    background: #ffc928;
+    background: var(--amber);
     border-radius: 999px;
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
     color: var(--ud-home-highlight-color);
@@ -116,7 +116,7 @@
 
     &:hover,
     &:focus {
-      background: #ffb700;
+      background: var(--amber-hover);
       color: var(--ud-home-highlight-color);
       transform: translateY(-32%) scale(1.04);
     }
@@ -188,14 +188,14 @@
   }
 
   &__excerpt {
-    color: #4f4f4f;
+    color: var(--text-muted);
     font-size: 16px;
     line-height: 1.78;
     margin: 0;
   }
 
   &__link {
-    color: #0f8777;
+    color: var(--primary-color);
     font-size: 16px;
     font-weight: 700;
     line-height: 1.2;

--- a/source/_assets/scss/home/_challenges.scss
+++ b/source/_assets/scss/home/_challenges.scss
@@ -1,7 +1,7 @@
 @use "../variables" as *;
 
 .ud-home-challenges {
-  background-color: #f9f9f9;
+  background-color: var(--bg-light);
 
   .ud-home-section {
     &__title {
@@ -9,7 +9,7 @@
     }
 
     &__subtitle {
-      color: #333333;
+      color: var(--text-gray);
     }
   }
 
@@ -22,7 +22,7 @@
     }
 
     &__icon {
-      background-color: #ffc107;
+      background-color: var(--amber);
       height: 170px;
       margin-bottom: 32px;
       width: 170px;
@@ -49,21 +49,7 @@
 
     &__body {
       p {
-        color: #333333;
-      }
-    }
-
-    &__actions {
-      .ud-main-btn {
-        background-color: #00796b;
-        border-color: #00796b;
-        color: var(--white);
-
-        &:hover {
-          background-color: #00685d;
-          border-color: #00685d;
-          color: var(--white);
-        }
+        color: var(--text-gray);
       }
     }
   }

--- a/source/_assets/scss/home/_cta.scss
+++ b/source/_assets/scss/home/_cta.scss
@@ -12,7 +12,7 @@
 
 .ud-home-cta__title {
   color: var(--white);
-  font-size: clamp(2.35rem, 4.2vw, 4.55rem);
+  font-size: var(--fs-h2-section);
   font-weight: 800;
   letter-spacing: -0.03em;
   line-height: 1.12;

--- a/source/_assets/scss/home/_shared.scss
+++ b/source/_assets/scss/home/_shared.scss
@@ -2,7 +2,7 @@
 
 .ud-home-section__title {
   color: var(--ud-home-section-title-color);
-  font-size: clamp(2.35rem, 4vw, 4rem);
+  font-size: var(--fs-h2-section);
   font-weight: 800;
   letter-spacing: -0.02em;
   line-height: 1.15;

--- a/source/_assets/scss/home/_solutions.scss
+++ b/source/_assets/scss/home/_solutions.scss
@@ -9,7 +9,7 @@
     }
 
     &__subtitle {
-      color: #3d4a5c;
+      color: var(--text-muted);
       font-size: 18px;
     }
   }
@@ -71,27 +71,6 @@
       margin-bottom: 25px;
 
       p { color: var(--text-muted); }
-    }
-
-    &__actions {
-      .ud-main-btn {
-        background: transparent;
-        border: 2px solid var(--primary-color);
-        border-radius: 18px;
-        color: var(--primary-color);
-        font-size: 14px;
-        min-height: 64px;
-
-        @media #{$xs, $sm} {
-          font-size: 13px;
-          min-height: 56px;
-        }
-
-        &:hover {
-          background-color: rgba(24, 76, 78, 0.08);
-          color: var(--primary-color);
-        }
-      }
     }
   }
 }

--- a/source/_assets/scss/home/_tokens.scss
+++ b/source/_assets/scss/home/_tokens.scss
@@ -5,16 +5,16 @@
   --ud-home-card-padding-laptop: 40px 50px 56px;
   --ud-home-card-padding-sm: 24px 20px 32px;
   --ud-home-card-radius: 0;
-  --ud-home-card-border: 1px solid #ececec;
+  --ud-home-card-border: 1px solid var(--border-light);
   --ud-home-card-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   --ud-home-card-title-color: var(--text-gray);
   --ud-home-card-body-color: var(--text-muted);
   --ud-home-section-title-color: var(--text-gray);
   --ud-home-section-subtitle-color: var(--text-muted);
-  --ud-home-clients-text-color: #004d40;
-  --ud-home-highlight-color: #0b5f55;
-  --ud-home-cta-bg: #00796b;
-  --ud-home-cta-button-bg: #ffc93d;
-  --ud-home-cta-button-bg-hover: #ffbe1f;
+  --ud-home-clients-text-color: var(--primary-color);
+  --ud-home-highlight-color: var(--primary-color);
+  --ud-home-cta-bg: var(--surface-dark);
+  --ud-home-cta-button-bg: var(--amber);
+  --ud-home-cta-button-bg-hover: var(--amber-hover);
   --ud-home-solutions-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
 }

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -6,7 +6,7 @@ description: "Learn the story of LibreSign and LibreCode, a cooperative of open-
 
 @section('body')
   @include('_partials.home.hero-section', [
-    'backgroundImage' => "linear-gradient(90deg, rgba(45,55,72,.96) 0%, rgba(45,55,72,.9) 33%, rgba(45,55,72,.72) 58%, rgba(45,55,72,.35) 100%), url('{$page->baseUrl}assets/images/about/hero.png')",
+    'backgroundImage' => "linear-gradient(90deg, rgba(18,60,64,.96) 0%, rgba(18,60,64,.9) 33%, rgba(18,60,64,.72) 58%, rgba(18,60,64,.35) 100%), url('{$page->baseUrl}assets/images/about/hero.png')",
     'title' => $page->t('Technology, People, and Open Source Software.'),
     'description' => $page->t('Learn the story of a cooperative of open-source specialists created to bring more freedom, transparency, and security to your digital world.'),
     'actions' => [


### PR DESCRIPTION
## Summary

UI consistency and accessibility pass over the whole site.

## Changes

- Consolidate all hardcoded colors into the token system in
  `_common.scss`; unify heading sizes with a shared type scale.
- Standardize color roles: teal = brand, amber = CTA on dark, orange = accent on light,
  cyan = focus ring only. About/FAQ heroes switch from slate to brand teal; header
  "Client Area" button and leftover cyan hovers switch to amber.
- Restore keyboard focus visibility (a global `outline: none` suppressed it) using
  `:focus-visible` with context-aware ring colors.
- Fix failing contrasts: footer links, error color, nav hover, input borders; contact
  form fields no longer look disabled.
- Honor `prefers-reduced-motion` (CSS + AOS); keep hidden floating buttons out of the
  tab order.
- Remove dead CSS and the 200px dead band below the footer.