### PR TITLE
[codex] point Try LibreSign button to account

### DIFF
--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -11,7 +11,7 @@
       'description' => $page->t('Reduce bureaucracy and speed up your processes: sign, manage, and validate documents with technology you control.'),
       'actions' => [
         [
-          'href' => locale_url($page, 'contact-us'),
+          'href' => 'https://account.libresign.coop/',
           'label' => $page->t('Try LibreSign'),
           'class' => 'btn ud-btn-solid-amber ud-btn-lg w-100 text-center',
         ],


### PR DESCRIPTION
# What changed
- Updated the homepage primary CTA “Try LibreSign” to point to `https://account.libresign.coop/`.

# Why
- The button was sending users to the contact page instead of the account area.

# Impact
- The main entry path now matches the intended destination for users who want to try LibreSign.
