### PR TITLE
feat: add shared header fragment bridge

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -17,5 +17,6 @@ $events->afterBuild([
     RemoveTranslationFiles::class,
     App\Listeners\GenerateSitemap::class,
     App\Listeners\CleanupCollectionDirectories::class,
+    App\Listeners\PushHeaderFragments::class,
     App\Listeners\PushFooterFragments::class,
 ]);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - .:/var/www/html
       - ${COMPOSER_HOME_DIR:-${HOME}/.composer}:/var/www/.composer/
       - ${NPM_CACHE_DIR:-${HOME}/.npm}:/var/www/.npm/
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     working_dir: /var/www/html
     environment:
       - HOME=/var/www/html
@@ -35,3 +37,9 @@ services:
       - CAMPAIGN_ID=${CAMPAIGN_ID:-123}
       - URL_SUITECRM=${URL_SUITECRM:-123}
       - URL_SITE=${URL_SITE:-http://localhost}
+      - LIBRESIGN_PUBLISH_HEADER_FRAGMENTS=${LIBRESIGN_PUBLISH_HEADER_FRAGMENTS:-false}
+      - LIBRESIGN_HEADER_WEBHOOK_URL=${LIBRESIGN_HEADER_WEBHOOK_URL:-}
+      - LIBRESIGN_HEADER_WEBHOOK_SECRET=${LIBRESIGN_HEADER_WEBHOOK_SECRET:-}
+      - LIBRESIGN_PUBLISH_FOOTER_FRAGMENTS=${LIBRESIGN_PUBLISH_FOOTER_FRAGMENTS:-false}
+      - LIBRESIGN_FOOTER_WEBHOOK_URL=${LIBRESIGN_FOOTER_WEBHOOK_URL:-}
+      - LIBRESIGN_FOOTER_WEBHOOK_SECRET=${LIBRESIGN_FOOTER_WEBHOOK_SECRET:-}

--- a/listeners/PushHeaderFragments.php
+++ b/listeners/PushHeaderFragments.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace App\Listeners;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use TightenCo\Jigsaw\Jigsaw;
+
+class PushHeaderFragments
+{
+    private const ASSET_BASE_TOKEN = '__LIBRESIGN_HEADER_ASSET_BASE_URL__';
+    private const HTML_FRAGMENT_SUFFIX = '/header/index.html';
+    private const PUBLISH_FLAG = 'LIBRESIGN_PUBLISH_HEADER_FRAGMENTS';
+
+    public function handle(Jigsaw $jigsaw): void
+    {
+        if (! $this->shouldPublish()) {
+            return;
+        }
+
+        $webhookUrl = trim((string) getenv('LIBRESIGN_HEADER_WEBHOOK_URL'));
+        $secret = trim((string) getenv('LIBRESIGN_HEADER_WEBHOOK_SECRET'));
+
+        if ($webhookUrl === '' || $secret === '') {
+            return;
+        }
+
+        $destinationPath = $jigsaw->getDestinationPath();
+        $manifest = $this->loadManifest($destinationPath . '/assets/build/manifest.json');
+        if ($manifest === []) {
+            return;
+        }
+
+        $cssArtifactPath = $this->resolveBuildArtifactPath($destinationPath, $manifest, 'source/_assets/scss/header-fragment.scss');
+        $jsArtifactPath = $this->resolveBuildArtifactPath($destinationPath, $manifest, 'source/_assets/js/header-fragment.js');
+
+        if ($cssArtifactPath === '' || $jsArtifactPath === '') {
+            return;
+        }
+
+        $fragments = $this->discoverFragmentFiles($destinationPath);
+
+        foreach ($fragments as $fragmentFile) {
+            $payload = $this->buildPayload(
+                $fragmentFile,
+                $destinationPath,
+                $cssArtifactPath,
+                $jsArtifactPath
+            );
+
+            if ($payload === []) {
+                continue;
+            }
+
+            $this->dispatch($webhookUrl, $secret, $payload);
+        }
+    }
+
+    private function loadManifest(string $manifestPath): array
+    {
+        if (! is_file($manifestPath)) {
+            return [];
+        }
+
+        $manifest = json_decode((string) file_get_contents($manifestPath), true);
+        return is_array($manifest) ? $manifest : [];
+    }
+
+    private function resolveBuildArtifactPath(string $destinationPath, array $manifest, string $entry): string
+    {
+        $file = $manifest[$entry]['file'] ?? '';
+        if (! is_string($file) || $file === '') {
+            return '';
+        }
+
+        return $destinationPath . '/assets/build/' . ltrim($file, '/');
+    }
+
+    private function discoverFragmentFiles(string $destinationPath): array
+    {
+        $files = [];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($destinationPath, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $fileInfo) {
+            if (! $fileInfo->isFile()) {
+                continue;
+            }
+
+            $pathname = str_replace('\\', '/', $fileInfo->getPathname());
+            $relativePath = ltrim(str_replace(str_replace('\\', '/', $destinationPath), '', $pathname), '/');
+
+            if (
+                str_starts_with($relativePath, 'fragments/')
+                && str_ends_with($relativePath, self::HTML_FRAGMENT_SUFFIX)
+            ) {
+                $files[] = $pathname;
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function buildPayload(string $fragmentFile, string $destinationPath, string $cssArtifactPath, string $jsArtifactPath): array
+    {
+        $html = (string) file_get_contents($fragmentFile);
+        $css = (string) file_get_contents($cssArtifactPath);
+        $js = (string) file_get_contents($jsArtifactPath);
+
+        $html = preg_replace('/\s+data-fragment-css="[^"]+"/', '', $html) ?? $html;
+        $html = preg_replace('/\s+data-fragment-js="[^"]+"/', '', $html) ?? $html;
+
+        $assets = [];
+
+        $htmlAssetPaths = $this->extractHtmlAssetPaths($html);
+        $cssAssetPaths = $this->extractCssAssetPaths($css);
+        $assetPaths = array_values(array_unique(array_merge($htmlAssetPaths, $cssAssetPaths)));
+
+        foreach ($assetPaths as $assetPath) {
+            $absolutePath = $destinationPath . '/' . ltrim($assetPath, '/');
+            if (! is_file($absolutePath)) {
+                continue;
+            }
+
+            $normalizedPath = $this->normalizeStoredAssetPath($assetPath);
+            $tokenizedUrl = self::ASSET_BASE_TOKEN . '/' . ltrim($normalizedPath, '/');
+
+            $html = str_replace($this->assetPublicUrlPatterns($assetPath), $tokenizedUrl, $html);
+            $css = str_replace($this->assetPublicUrlPatterns($assetPath), $tokenizedUrl, $css);
+
+            $assets[] = [
+                'path' => $normalizedPath,
+                'content_base64' => base64_encode((string) file_get_contents($absolutePath)),
+                'mime' => mime_content_type($absolutePath) ?: 'application/octet-stream',
+            ];
+        }
+
+        $relativeFragmentPath = ltrim(str_replace(str_replace('\\', '/', $destinationPath), '', $fragmentFile), '/');
+        $locale = $this->extractLocaleFromFragmentPath($relativeFragmentPath);
+
+        return [
+            'locale' => $locale,
+            'version' => hash('sha256', $html . "\n" . $css . "\n" . $js),
+            'generated_at' => gmdate(DATE_ATOM),
+            'html' => $html,
+            'css' => $css,
+            'js' => $js,
+            'assets' => $assets,
+        ];
+    }
+
+    private function extractHtmlAssetPaths(string $html): array
+    {
+        preg_match_all('/(?:src)=\"([^\"]+)\"/i', $html, $matches);
+        return $this->normalizeAssetPaths($matches[1] ?? []);
+    }
+
+    private function extractCssAssetPaths(string $css): array
+    {
+        preg_match_all('/url\(([^)]+)\)/i', $css, $matches);
+        return $this->normalizeAssetPaths($matches[1] ?? []);
+    }
+
+    private function normalizeAssetPaths(array $values): array
+    {
+        $paths = [];
+
+        foreach ($values as $value) {
+            $value = trim((string) $value, " \t\n\r\0\x0B'\"");
+            $path = parse_url($value, PHP_URL_PATH);
+            if (! is_string($path) || $path === '') {
+                continue;
+            }
+
+            if (! str_starts_with($path, '/assets/')) {
+                continue;
+            }
+
+            $paths[] = ltrim($path, '/');
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    private function normalizeStoredAssetPath(string $assetPath): string
+    {
+        return ltrim(preg_replace('#^assets/#', '', ltrim($assetPath, '/')) ?? ltrim($assetPath, '/'), '/');
+    }
+
+    private function assetPublicUrlPatterns(string $assetPath): array
+    {
+        $path = '/' . ltrim($assetPath, '/');
+
+        return [
+            'http://localhost:8081' . $path,
+            'https://libresign.coop' . $path,
+            $path,
+        ];
+    }
+
+    private function dispatch(string $webhookUrl, string $secret, array $payload): void
+    {
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($body)) {
+            return;
+        }
+
+        $timestamp = (string) time();
+        $signature = hash_hmac('sha256', $timestamp . "\n" . $body, $secret);
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => implode("\r\n", [
+                    'Content-Type: application/json',
+                    'Content-Length: ' . strlen($body),
+                    'X-LibreSign-Timestamp: ' . $timestamp,
+                    'X-LibreSign-Signature: sha256=' . $signature,
+                ]),
+                'content' => $body,
+                'timeout' => 20,
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        @file_get_contents($webhookUrl, false, $context);
+    }
+
+    private function shouldPublish(): bool
+    {
+        return filter_var(getenv(self::PUBLISH_FLAG), FILTER_VALIDATE_BOOL) === true;
+    }
+
+    private function extractLocaleFromFragmentPath(string $relativeFragmentPath): string
+    {
+        $normalized = trim(str_replace('\\', '/', $relativeFragmentPath), '/');
+
+        if (! str_starts_with($normalized, 'fragments/')) {
+            return '';
+        }
+
+        $suffix = '/header/index.html';
+        if (! str_ends_with($normalized, $suffix)) {
+            return '';
+        }
+
+        $candidate = substr($normalized, strlen('fragments/'));
+        $candidate = substr($candidate, 0, -strlen($suffix));
+
+        return trim((string) $candidate, '/');
+    }
+}

--- a/source/_assets/js/header-fragment.js
+++ b/source/_assets/js/header-fragment.js
@@ -1,0 +1,154 @@
+const HEADER_ROOT_SELECTOR = '.libresign-site-header-fragment';
+const DESKTOP_BREAKPOINT = 1400;
+
+const root = document.querySelector(HEADER_ROOT_SELECTOR);
+
+if (root) {
+  const header = root.querySelector('[data-libresign-header]');
+  const spacer = root.querySelector('.libresign-site-header-fragment__spacer');
+  const navToggle = root.querySelector('[data-libresign-header-toggle]');
+  const mainNavigation = root.querySelector('#main-navigation');
+  const dropdownToggles = Array.from(root.querySelectorAll('[data-libresign-dropdown-toggle]'));
+  const skipLink = root.querySelector('.skip-to-content');
+
+  const updateHeaderOffset = () => {
+    if (!header || !spacer) {
+      return;
+    }
+
+    const offset = header.offsetHeight || 76;
+    root.style.setProperty('--header-offset', `${offset}px`);
+    spacer.style.height = `${offset}px`;
+  };
+
+  const closeAllDropdowns = (exceptToggle = null) => {
+    dropdownToggles.forEach((toggle) => {
+      const menuId = toggle.getAttribute('aria-controls');
+      const menu = menuId ? root.querySelector(`#${menuId}`) : null;
+      const shouldStayOpen = exceptToggle === toggle;
+
+      toggle.classList.toggle('show', shouldStayOpen);
+      toggle.setAttribute('aria-expanded', shouldStayOpen ? 'true' : 'false');
+
+      if (menu) {
+        menu.classList.toggle('show', shouldStayOpen);
+        menu.hidden = !shouldStayOpen;
+      }
+    });
+  };
+
+  const setNavigationOpen = (isOpen) => {
+    if (!navToggle || !mainNavigation) {
+      return;
+    }
+
+    navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    navToggle.classList.toggle('is-open', isOpen);
+    mainNavigation.classList.toggle('show', isOpen);
+    mainNavigation.hidden = !isOpen;
+
+    if (!isOpen) {
+      closeAllDropdowns();
+    }
+  };
+
+  if (mainNavigation) {
+    mainNavigation.hidden = window.innerWidth < DESKTOP_BREAKPOINT;
+  }
+
+  dropdownToggles.forEach((toggle) => {
+    const menuId = toggle.getAttribute('aria-controls');
+    const menu = menuId ? root.querySelector(`#${menuId}`) : null;
+
+    if (menu) {
+      menu.hidden = true;
+    }
+
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      const isOpen = toggle.classList.contains('show');
+      if (isOpen) {
+        closeAllDropdowns();
+        return;
+      }
+
+      closeAllDropdowns(toggle);
+    });
+  });
+
+  if (navToggle && mainNavigation) {
+    navToggle.addEventListener('click', () => {
+      const isOpen = navToggle.getAttribute('aria-expanded') === 'true';
+      setNavigationOpen(!isOpen);
+    });
+  }
+
+  if (skipLink) {
+    skipLink.addEventListener('click', (event) => {
+      const preferredTarget = document.querySelector('#main-content, #wp--skip-link--target, main');
+      const href = skipLink.getAttribute('href') || '';
+      const target = href.startsWith('#') ? document.querySelector(href) : null;
+      const focusTarget = target || preferredTarget;
+
+      if (!focusTarget) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (!focusTarget.hasAttribute('tabindex')) {
+        focusTarget.setAttribute('tabindex', '-1');
+      }
+
+      focusTarget.focus({ preventScroll: false });
+      focusTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
+  document.addEventListener('click', (event) => {
+    if (!root.contains(event.target)) {
+      closeAllDropdowns();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeAllDropdowns();
+      setNavigationOpen(false);
+      navToggle?.focus();
+    }
+  });
+
+  const handleResize = () => {
+    updateHeaderOffset();
+
+    if (!mainNavigation) {
+      return;
+    }
+
+    if (window.innerWidth >= DESKTOP_BREAKPOINT) {
+      mainNavigation.hidden = false;
+      mainNavigation.classList.remove('show');
+      navToggle?.setAttribute('aria-expanded', 'false');
+      navToggle?.classList.remove('is-open');
+    } else {
+      const isOpen = navToggle?.getAttribute('aria-expanded') === 'true';
+      mainNavigation.hidden = !isOpen;
+      if (!isOpen) {
+        mainNavigation.classList.remove('show');
+      }
+    }
+  };
+
+  if (typeof ResizeObserver !== 'undefined' && header) {
+    const observer = new ResizeObserver(updateHeaderOffset);
+    observer.observe(header);
+  }
+
+  window.addEventListener('resize', handleResize);
+  window.addEventListener('load', updateHeaderOffset);
+
+  handleResize();
+  updateHeaderOffset();
+}

--- a/source/_assets/scss/header-fragment.scss
+++ b/source/_assets/scss/header-fragment.scss
@@ -1,0 +1,595 @@
+@import "@fontsource/montserrat/400.css";
+@import "@fontsource/montserrat/500.css";
+@import "@fontsource/montserrat/600.css";
+@import "@fontsource/montserrat/700.css";
+@import "@fontsource/montserrat/800.css";
+
+.libresign-site-header-fragment {
+  --font: "Montserrat", sans-serif;
+  --primary-color: #184c4e;
+  --primary-hover: #0f3739;
+  --accent-color: #d97706;
+  --amber: #ffc107;
+  --amber-hover: #ffb300;
+  --color-dark: #263238;
+  --heading-color: #212b36;
+  --body-color: #2d3748;
+  --white: #ffffff;
+  --focus-color-light: #005e54;
+  --focus-color-dark: #00dbff;
+  --focus-color: var(--focus-color-dark);
+  --header-offset: 76px;
+  color: var(--body-color);
+  font-family: var(--font);
+  position: relative;
+}
+
+.libresign-site-header-fragment,
+.libresign-site-header-fragment *,
+.libresign-site-header-fragment *::before,
+.libresign-site-header-fragment *::after {
+  box-sizing: border-box;
+}
+
+.libresign-site-header-fragment img,
+.libresign-site-header-fragment svg {
+  vertical-align: middle;
+}
+
+.libresign-site-header-fragment img {
+  max-width: 100%;
+}
+
+.libresign-site-header-fragment a,
+.libresign-site-header-fragment button,
+.libresign-site-header-fragment input,
+.libresign-site-header-fragment textarea {
+  transition: all 0.3s ease-out;
+}
+
+.libresign-site-header-fragment a,
+.libresign-site-header-fragment a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.libresign-site-header-fragment a:focus-visible,
+.libresign-site-header-fragment button:focus-visible,
+.libresign-site-header-fragment [tabindex]:focus-visible {
+  outline: 3px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
+.libresign-site-header-fragment :focus:not(:focus-visible) {
+  box-shadow: none;
+  outline: none;
+}
+
+.libresign-site-header-fragment .visually-hidden {
+  clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  position: absolute !important;
+  overflow: hidden !important;
+}
+
+.libresign-site-header-fragment .container {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+@media (min-width: 576px) {
+  .libresign-site-header-fragment .container {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .libresign-site-header-fragment .container {
+    max-width: 720px;
+  }
+}
+
+@media (min-width: 992px) {
+  .libresign-site-header-fragment .container {
+    max-width: 960px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .libresign-site-header-fragment .container {
+    max-width: 1140px;
+  }
+}
+
+@media (min-width: 1400px) {
+  .libresign-site-header-fragment .container {
+    max-width: 1320px;
+  }
+}
+
+.libresign-site-header-fragment .d-flex {
+  display: flex;
+}
+
+.libresign-site-header-fragment .align-items-center {
+  align-items: center;
+}
+
+.libresign-site-header-fragment .mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.libresign-site-header-fragment .dropdown {
+  position: relative;
+}
+
+.libresign-site-header-fragment__spacer {
+  display: block;
+  height: var(--header-offset);
+}
+
+.libresign-site-header-fragment .skip-to-content {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 120;
+  padding: 12px 24px;
+  background-color: var(--amber);
+  color: var(--primary-color);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 0 0 8px 0;
+}
+
+.libresign-site-header-fragment .skip-to-content:focus {
+  left: 0;
+}
+
+.libresign-site-header-fragment .ud-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 99;
+  background-color: var(--color-dark);
+}
+
+body.admin-bar .libresign-site-header-fragment .ud-header {
+  top: 32px;
+}
+
+body.admin-bar .libresign-site-header-fragment__spacer {
+  height: var(--header-offset);
+}
+
+@media (max-width: 782px) {
+  body.admin-bar .libresign-site-header-fragment .ud-header {
+    top: 46px;
+  }
+}
+
+.libresign-site-header-fragment .ud-header > .container {
+  width: 100%;
+  max-width: 1920px;
+  padding-left: 72px;
+  padding-right: 72px;
+}
+
+@media (max-width: 991px) {
+  .libresign-site-header-fragment .ud-header > .container {
+    padding-left: 40px;
+    padding-right: 40px;
+  }
+}
+
+@media (max-width: 575px) {
+  .libresign-site-header-fragment .ud-header > .container {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+.libresign-site-header-fragment .navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px 0;
+}
+
+.libresign-site-header-fragment .navbar-nav.container {
+  max-width: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.libresign-site-header-fragment .navbar-brand {
+  flex: 0 0 auto;
+  padding: 0;
+}
+
+.libresign-site-header-fragment .navbar-brand img {
+  max-height: 40px;
+}
+
+@media (max-width: 1199px) {
+  .libresign-site-header-fragment .navbar-brand img {
+    max-height: 36px;
+  }
+}
+
+.libresign-site-header-fragment .navbar-collapse {
+  flex-grow: 0;
+}
+
+.libresign-site-header-fragment .navbar-nav {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.libresign-site-header-fragment .nav-item {
+  position: relative;
+}
+
+.libresign-site-header-fragment .nav-item > .nav-link {
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--white);
+  padding: 8px 0;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.libresign-site-header-fragment .nav-item > .nav-link:hover:not(.link-button),
+.libresign-site-header-fragment .nav-item > .nav-link:focus:not(.link-button),
+.libresign-site-header-fragment .nav-item > .nav-link.active:not(.link-button),
+.libresign-site-header-fragment .nav-item > .nav-link.show:not(.link-button) {
+  color: var(--white);
+  opacity: 0.75;
+  text-decoration: underline;
+  text-underline-offset: 6px;
+}
+
+.libresign-site-header-fragment .ud-nav-dropdown-toggle {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: var(--white);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  line-height: 1.5;
+  margin: 0;
+  min-height: 40px;
+  padding: 8px 0;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.libresign-site-header-fragment .ud-nav-dropdown-toggle::after {
+  content: "";
+  width: 0;
+  height: 0;
+  margin-left: 0;
+  margin-top: 2px;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid currentColor;
+  border-bottom: 0;
+  transform-origin: center;
+  transition: transform 0.3s ease;
+}
+
+.libresign-site-header-fragment .ud-nav-dropdown-toggle.show::after {
+  transform: rotate(180deg);
+  margin-top: -2px;
+}
+
+.libresign-site-header-fragment .ud-nav-submenu,
+.libresign-site-header-fragment .ud-submenu {
+  display: none;
+  list-style: none;
+  margin: 0;
+}
+
+.libresign-site-header-fragment .ud-nav-submenu.show {
+  display: block;
+}
+
+.libresign-site-header-fragment .ud-submenu.show {
+  display: flex;
+}
+
+.libresign-site-header-fragment .ud-nav-submenu {
+  margin-top: 12px;
+  min-width: 220px;
+  padding: 8px;
+  border: none;
+  border-radius: 12px;
+  background: var(--white);
+  box-shadow: 0 15px 44px rgba(140, 140, 140, 0.18);
+  position: absolute;
+  top: 100%;
+  left: 0;
+}
+
+.libresign-site-header-fragment .ud-nav-submenu li + li {
+  margin-top: 4px;
+}
+
+.libresign-site-header-fragment .ud-nav-submenu-link {
+  border-radius: 8px;
+  color: var(--heading-color);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 10px 14px;
+  white-space: normal;
+  display: inline-flex;
+  min-width: 100%;
+}
+
+.libresign-site-header-fragment .ud-nav-submenu-link:hover,
+.libresign-site-header-fragment .ud-nav-submenu-link:focus {
+  background: rgba(24, 76, 78, 0.08);
+  color: var(--primary-color);
+}
+
+.libresign-site-header-fragment .ud-nav-submenu-link--all {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+.libresign-site-header-fragment .link-button {
+  background-color: var(--amber);
+  color: var(--primary-color);
+  height: 38px;
+  border-radius: 32px;
+  font-weight: 600;
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.libresign-site-header-fragment .link-button:hover,
+.libresign-site-header-fragment .link-button:focus {
+  background-color: var(--amber-hover);
+  color: var(--primary-color);
+  opacity: 1;
+  text-decoration: none;
+}
+
+.libresign-site-header-fragment #customer-area-link {
+  margin-left: 24px;
+}
+
+.libresign-site-header-fragment .selector {
+  position: relative;
+  padding: 8px 0;
+}
+
+.libresign-site-header-fragment .selector .dropdown-toggle {
+  background: none;
+  border: none;
+  color: var(--white);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-right: 12px;
+  cursor: pointer;
+}
+
+.libresign-site-header-fragment .selector .dropdown-toggle img {
+  width: 20px;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+}
+
+.libresign-site-header-fragment .selector .dropdown-toggle:hover,
+.libresign-site-header-fragment .selector .dropdown-toggle.show {
+  opacity: 0.75;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu {
+  z-index: 100;
+  position: absolute;
+  width: 128px;
+  background: var(--white);
+  top: 100%;
+  margin-top: 16px;
+  padding: 8px 16px;
+  box-shadow: 0 15px 44px rgba(140, 140, 140, 0.18);
+  border-radius: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column;
+  gap: 8px;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu-link {
+  color: var(--heading-color);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu-link img {
+  width: 24px;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu-link span {
+  text-transform: uppercase;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu-link--cta {
+  color: var(--primary-color);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu-link--cta span {
+  text-transform: none;
+}
+
+.libresign-site-header-fragment .selector .ud-submenu-link--cta:hover {
+  color: var(--primary-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.libresign-site-header-fragment .navbar-toggler {
+  display: none;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.libresign-site-header-fragment .navbar-toggler .toggler-icon {
+  width: 30px;
+  height: 2px;
+  background-color: var(--white);
+  display: block;
+  margin: 5px 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.libresign-site-header-fragment .navbar-toggler.is-open .toggler-icon:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.libresign-site-header-fragment .navbar-toggler.is-open .toggler-icon:nth-child(2) {
+  opacity: 0;
+}
+
+.libresign-site-header-fragment .navbar-toggler.is-open .toggler-icon:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.libresign-site-header-fragment hr {
+  border: 0;
+  border-top: 1px solid rgba(33, 43, 54, 0.12);
+  margin: 8px 0;
+}
+
+@media (max-width: 1399px) {
+  .libresign-site-header-fragment .navbar {
+    gap: 16px;
+  }
+
+  .libresign-site-header-fragment .navbar-collapse {
+    display: none;
+    position: fixed;
+    top: 76px;
+    left: 0;
+    width: 100vw;
+    max-height: calc(100vh - 76px);
+    overflow-y: auto;
+    background-color: var(--color-dark);
+    z-index: 98;
+    box-shadow: 0 15px 20px rgba(0, 0, 0, 0.1);
+    padding: 0 24px 16px;
+  }
+
+  body.admin-bar .libresign-site-header-fragment .navbar-collapse {
+    top: 108px;
+    max-height: calc(100vh - 108px);
+  }
+
+  @media (max-width: 782px) {
+    body.admin-bar .libresign-site-header-fragment .navbar-collapse {
+      top: 122px;
+      max-height: calc(100vh - 122px);
+    }
+  }
+
+  .libresign-site-header-fragment .navbar-collapse.show {
+    display: block;
+  }
+
+  .libresign-site-header-fragment .navbar-toggler {
+    display: block;
+  }
+
+  .libresign-site-header-fragment .navbar-nav {
+    gap: 4px;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .libresign-site-header-fragment .nav-item,
+  .libresign-site-header-fragment .nav-item > .nav-link,
+  .libresign-site-header-fragment .ud-nav-dropdown-toggle {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .libresign-site-header-fragment .ud-nav-submenu {
+    min-width: 0;
+    width: 100%;
+    margin-top: 4px;
+    padding: 8px 0 0 16px;
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
+    position: static;
+    transform: none !important;
+    inset: auto !important;
+  }
+
+  .libresign-site-header-fragment .ud-nav-submenu li + li {
+    margin-top: 0;
+  }
+
+  .libresign-site-header-fragment .ud-nav-submenu-link {
+    color: var(--white);
+    font-size: 15px;
+    font-weight: 400;
+    opacity: 0.85;
+    padding: 8px 0;
+  }
+
+  .libresign-site-header-fragment .ud-nav-submenu-link:hover,
+  .libresign-site-header-fragment .ud-nav-submenu-link:focus {
+    background: transparent;
+    color: var(--white);
+    opacity: 1;
+  }
+
+  .libresign-site-header-fragment #customer-area-link {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .libresign-site-header-fragment .link-button {
+    padding: 0 16px;
+  }
+}
+
+@media (min-width: 1400px) {
+  .libresign-site-header-fragment .navbar-collapse {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    flex: 1 1 auto;
+  }
+}

--- a/source/_layouts/header.blade.php
+++ b/source/_layouts/header.blade.php
@@ -1,9 +1,38 @@
-<a href="#main-content" class="skip-to-content">{{ $page->t("Skip to main content") }}</a>
-<header class="ud-header">
-  <div class="container">
+@php
+    $isHeaderFragment = (bool) $page->get('isHeaderFragment');
+    $siteOrigin = rtrim($page->get('siteOrigin') ?: $page->baseUrl, '/');
+    $headerAssetBase = $isHeaderFragment ? $siteOrigin . '/' : $page->baseUrl;
+    $headerCssUrl = $isHeaderFragment ? $siteOrigin . vite('source/_assets/scss/header-fragment.scss') : '';
+    $headerJsUrl = $isHeaderFragment ? $siteOrigin . vite('source/_assets/js/header-fragment.js') : '';
+    $headerLocaleUrl = function (string $path = '') use ($page, $isHeaderFragment, $siteOrigin) {
+        $url = locale_url($page, $path);
+
+        if (! $isHeaderFragment) {
+            return $url;
+        }
+
+        return $siteOrigin . '/' . ltrim($url, '/');
+    };
+    $headerTranslateUrl = function (string $localeCode = '') use ($page, $isHeaderFragment, $siteOrigin) {
+        $url = translate_url($page, $localeCode);
+
+        if (! $isHeaderFragment) {
+            return $url;
+        }
+
+        return $siteOrigin . '/' . ltrim($url, '/');
+    };
+@endphp
+
+<div class="libresign-site-header-fragment"
+     @if($headerCssUrl) data-fragment-css="{{ $headerCssUrl }}" @endif
+     @if($headerJsUrl) data-fragment-js="{{ $headerJsUrl }}" @endif>
+  <a href="#main-content" class="skip-to-content">{{ $page->t("Skip to main content") }}</a>
+  <header class="ud-header" data-libresign-header>
+    <div class="container">
       <nav class="navbar navbar-expand-xl" aria-label="{{ $page->t('Main navigation') }}">
-      <a class="navbar-brand" href="{{ locale_url($page, '')  }}" aria-label="{{ $page->t('LibreSign home') }}">
-        <img src="{{ $page->baseUrl }}assets/images/logo/logo.svg" alt="LibreSign">
+      <a class="navbar-brand" href="{{ $headerLocaleUrl('')  }}" aria-label="{{ $page->t('LibreSign home') }}">
+        <img src="{{ $headerAssetBase }}assets/images/logo/logo.svg" alt="LibreSign">
       </a>
       <div class="collapse navbar-collapse mx-auto" id="main-navigation">
         <ul class="navbar-nav container">
@@ -12,36 +41,39 @@
                href="#"
                role="button"
                id="solutions-menu-toggle"
-               data-bs-toggle="dropdown"
+               data-libresign-dropdown-toggle
+               aria-controls="solutions-menu"
                aria-expanded="false"
                aria-label="{{ $page->t('Open solutions submenu') }}">
               {{ $page->t("Solutions") }}
             </a>
             <ul class="dropdown-menu ud-nav-submenu"
+                id="solutions-menu"
+                hidden
                 aria-labelledby="solutions-menu-toggle"
                 aria-label="{{ $page->t('Solutions submenu') }}">
               <li>
-                <a class="dropdown-item ud-nav-submenu-link" href="{{ locale_url($page, 'lawyers') }}">
+                <a class="dropdown-item ud-nav-submenu-link" href="{{ $headerLocaleUrl('lawyers') }}">
                   {{ $page->t('Lawyers') }}
                 </a>
               </li>
               <li>
-                <a class="dropdown-item ud-nav-submenu-link" href="{{ locale_url($page, 'tecnical-details') }}">
+                <a class="dropdown-item ud-nav-submenu-link" href="{{ $headerLocaleUrl('tecnical-details') }}">
                   {{ $page->t('IT Professionals') }}
                 </a>
               </li>
               <li>
-                <a class="dropdown-item ud-nav-submenu-link" href="{{ locale_url($page, 'company-solutions') }}">
+                <a class="dropdown-item ud-nav-submenu-link" href="{{ $headerLocaleUrl('company-solutions') }}">
                   {{ $page->t('Companies') }}
                 </a>
               </li>
               <li>
-                <a class="dropdown-item ud-nav-submenu-link" href="{{ locale_url($page, 'cooperatives') }}">
+                <a class="dropdown-item ud-nav-submenu-link" href="{{ $headerLocaleUrl('cooperatives') }}">
                   {{ $page->t('Cooperatives') }}
                 </a>
               </li>
               <li>
-                <a class="dropdown-item ud-nav-submenu-link" href="{{ locale_url($page, 'public-sector') }}">
+                <a class="dropdown-item ud-nav-submenu-link" href="{{ $headerLocaleUrl('public-sector') }}">
                   {{ $page->t('Public Sector') }}
                 </a>
               </li>
@@ -52,12 +84,15 @@
                href="#"
                role="button"
                id="features-menu-toggle"
-               data-bs-toggle="dropdown"
+               data-libresign-dropdown-toggle
+               aria-controls="features-menu"
                aria-expanded="false"
                aria-label="{{ $page->t('Open features submenu') }}">
               {{$page->t("Features")}}
             </a>
             <ul class="dropdown-menu ud-nav-submenu"
+                id="features-menu"
+                hidden
                 aria-labelledby="features-menu-toggle"
                 aria-label="{{ $page->t('Features submenu') }}">
               @foreach($page->getFromCategory('featured') as $featuredPost)
@@ -69,23 +104,23 @@
               @endforeach
               <li><hr class="dropdown-divider"></li>
               <li>
-                <a class="dropdown-item ud-nav-submenu-link ud-nav-submenu-link--all" href="{{ locale_url($page, 'features') }}">
+                <a class="dropdown-item ud-nav-submenu-link ud-nav-submenu-link--all" href="{{ $headerLocaleUrl('features') }}">
                   {{ $page->t('All Features →') }}
                 </a>
               </li>
             </ul>
           </li>
           <li class="nav-item">
-            <a class="nav-link ud-menu-scroll" href="{{ locale_url($page, 'pricing') }}">{{ $page->t('Plans and Pricing')}}</a>
+            <a class="nav-link ud-menu-scroll" href="{{ $headerLocaleUrl('pricing') }}">{{ $page->t('Plans and Pricing')}}</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link ud-menu-scroll" href="{{ locale_url($page, 'about') }}">{{ $page->t("About") }}</a>
+            <a class="nav-link ud-menu-scroll" href="{{ $headerLocaleUrl('about') }}">{{ $page->t("About") }}</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link ud-menu-scroll" href="{{ locale_url($page, 'posts') }}">{{ $page->t("Blog") }}</a>
+            <a class="nav-link ud-menu-scroll" href="{{ $headerLocaleUrl('posts') }}">{{ $page->t("Blog") }}</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link ud-menu-scroll" href="{{ locale_url($page, 'contact-us') }}">{{ $page->t("Contact") }}</a>
+            <a class="nav-link ud-menu-scroll" href="{{ $headerLocaleUrl('contact-us') }}">{{ $page->t("Contact") }}</a>
           </li>
           <li class="nav-item" id="customer-area-link">
             <a class="nav-link ud-menu-scroll link-button" href="https://account.libresign.coop/" target="_blank" rel="noopener noreferrer">
@@ -103,20 +138,21 @@
         <div class="dropdown selector">
           <button class="dropdown-toggle ud-nav-dropdown-toggle"
                   type="button"
-                  data-bs-toggle="dropdown"
+                  data-libresign-dropdown-toggle
+                  aria-controls="language-menu"
                   aria-expanded="false"
                   aria-label="{{ $page->t('Select language') }}">
-            <img src="{{ $page->baseUrl }}assets/images/icon/languages/{{ $activeLocale }}.svg" alt="" aria-hidden="true">
+            <img src="{{ $headerAssetBase }}assets/images/icon/languages/{{ $activeLocale }}.svg" alt="" aria-hidden="true">
             <span class="visually-hidden">{{ $page->t('Current language') }}: {{ $page->locales()[$activeLocale] ?? 'English' }}</span>
           </button>
-          <ul class="dropdown-menu ud-submenu" id="language-menu" aria-label="{{ $page->t('Language selection') }}">
+          <ul class="dropdown-menu ud-submenu" id="language-menu" hidden aria-label="{{ $page->t('Language selection') }}">
           @foreach($page->locales() as $localeCode => $localeName)
             <li class="ud-submenu-item">
               <a class="ud-nav-submenu-link ud-submenu-link"
-                 href="{{ translate_url($page, $localeCode) }}"
+                 href="{{ $headerTranslateUrl($localeCode) }}"
                  lang="{{ $localeCode ?: 'en' }}"
                  aria-label="{{ $page->t('Switch to') }} {{ $localeName }}">
-                <img src="{{ $page->baseUrl }}assets/images/icon/languages/{{ $localeCode ?: 'en' }}.svg" alt="" aria-hidden="true">
+                <img src="{{ $headerAssetBase }}assets/images/icon/languages/{{ $localeCode ?: 'en' }}.svg" alt="" aria-hidden="true">
                 <span>{{ $localeCode ?: 'en'}}</span>
               </a>
             </li>
@@ -134,9 +170,8 @@
           </ul>
         </div>
         <button class="navbar-toggler collapsed"
+          data-libresign-header-toggle
                 type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#main-navigation"
                 aria-label="{{$page->t("Toggle navigation menu")}}"
                 aria-expanded="false"
                 aria-controls="main-navigation">
@@ -147,4 +182,8 @@
       </div>
     </nav>
   </div>
-</header>
+  </header>
+  @if($isHeaderFragment)
+    <div class="libresign-site-header-fragment__spacer" aria-hidden="true"></div>
+  @endif
+</div>

--- a/source/fragments/header.blade.php
+++ b/source/fragments/header.blade.php
@@ -1,0 +1,7 @@
+---
+title: "LibreSign Header Fragment"
+description: "Embeddable LibreSign header fragment for WordPress integration."
+noindex: true
+isHeaderFragment: true
+---
+@include('_layouts.header')

--- a/tests/Unit/Listeners/PushFragmentsTest.php
+++ b/tests/Unit/Listeners/PushFragmentsTest.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Listeners;
+
+use App\Listeners\PushFooterFragments;
+use App\Listeners\PushHeaderFragments;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class PushFragmentsTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempDir = sys_get_temp_dir() . '/libresign-push-fragments-' . bin2hex(random_bytes(8));
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteDirectory($this->tempDir);
+
+        putenv('LIBRESIGN_PUBLISH_HEADER_FRAGMENTS');
+        putenv('LIBRESIGN_PUBLISH_FOOTER_FRAGMENTS');
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('listenerProvider')]
+    public function testShouldPublishDependsOnEnvironmentFlag(string $listenerClass, string $publishFlag): void
+    {
+        $listener = new $listenerClass();
+
+        putenv($publishFlag . '=false');
+        self::assertFalse($this->invokePrivateMethod($listener, 'shouldPublish'));
+
+        putenv($publishFlag . '=true');
+        self::assertTrue($this->invokePrivateMethod($listener, 'shouldPublish'));
+    }
+
+    #[DataProvider('listenerProvider')]
+    public function testLoadManifestReturnsDecodedArrayAndEmptyArrayWhenMissing(string $listenerClass): void
+    {
+        $listener = new $listenerClass();
+        $manifestPath = $this->tempDir . '/manifest.json';
+
+        self::assertSame([], $this->invokePrivateMethod($listener, 'loadManifest', [$manifestPath]));
+
+        file_put_contents($manifestPath, json_encode([
+            'source/_assets/scss/example.scss' => ['file' => 'assets/example.css'],
+        ], JSON_THROW_ON_ERROR));
+
+        self::assertSame(
+            ['source/_assets/scss/example.scss' => ['file' => 'assets/example.css']],
+            $this->invokePrivateMethod($listener, 'loadManifest', [$manifestPath])
+        );
+    }
+
+    #[DataProvider('listenerProvider')]
+    public function testResolveBuildArtifactPathUsesManifestFile(string $listenerClass): void
+    {
+        $listener = new $listenerClass();
+        $destinationPath = '/tmp/build';
+        $manifest = [
+            'source/_assets/scss/example.scss' => ['file' => 'assets/example-123.css'],
+        ];
+
+        self::assertSame(
+            '/tmp/build/assets/build/assets/example-123.css',
+            $this->invokePrivateMethod($listener, 'resolveBuildArtifactPath', [
+                $destinationPath,
+                $manifest,
+                'source/_assets/scss/example.scss',
+            ])
+        );
+
+        self::assertSame(
+            '',
+            $this->invokePrivateMethod($listener, 'resolveBuildArtifactPath', [
+                $destinationPath,
+                $manifest,
+                'source/_assets/scss/missing.scss',
+            ])
+        );
+    }
+
+    #[DataProvider('fragmentStructureProvider')]
+    public function testDiscoverFragmentFilesReturnsSortedMatchingFragmentFilesOnly(
+        string $listenerClass,
+        string $fragmentName,
+        array $expectedRelativePaths
+    ): void {
+        $listener = new $listenerClass();
+        $destinationPath = $this->tempDir . '/build';
+
+        $this->writeFile($destinationPath . '/fragments/' . $fragmentName . '/index.html', '<div>default</div>');
+        $this->writeFile($destinationPath . '/fragments/pt-BR/' . $fragmentName . '/index.html', '<div>pt-BR</div>');
+        $this->writeFile($destinationPath . '/fragments/fr/' . $fragmentName . '/index.html', '<div>fr</div>');
+        $this->writeFile($destinationPath . '/fragments/pt-BR/other/index.html', '<div>ignore</div>');
+        $this->writeFile($destinationPath . '/fragments/' . ($fragmentName === 'header' ? 'footer' : 'header') . '/index.html', '<div>ignore sibling</div>');
+
+        $files = $this->invokePrivateMethod($listener, 'discoverFragmentFiles', [$destinationPath]);
+        $relativePaths = array_map(
+            static fn (string $file): string => ltrim(str_replace(str_replace('\\', '/', $destinationPath), '', str_replace('\\', '/', $file)), '/'),
+            $files
+        );
+
+        self::assertSame($expectedRelativePaths, $relativePaths);
+    }
+
+    #[DataProvider('listenerProvider')]
+    public function testNormalizeAssetPathsFiltersAssetsAndRemovesDuplicates(string $listenerClass): void
+    {
+        $listener = new $listenerClass();
+
+        $paths = $this->invokePrivateMethod($listener, 'normalizeAssetPaths', [[
+            'http://localhost:8081/assets/images/logo.svg',
+            '/assets/images/logo.svg',
+            "'/assets/images/logo.svg'",
+            '/assets/build/assets/header-fragment.css',
+            '/not-assets/ignore.svg',
+            'data:image/png;base64,abc',
+            '',
+        ]]);
+
+        self::assertSame([
+            'assets/images/logo.svg',
+            'assets/build/assets/header-fragment.css',
+        ], $paths);
+    }
+
+    #[DataProvider('listenerProvider')]
+    public function testNormalizeStoredAssetPathRemovesLeadingAssetsDirectory(string $listenerClass): void
+    {
+        $listener = new $listenerClass();
+
+        self::assertSame(
+            'images/logo.svg',
+            $this->invokePrivateMethod($listener, 'normalizeStoredAssetPath', ['assets/images/logo.svg'])
+        );
+
+        self::assertSame(
+            'build/assets/file.woff2',
+            $this->invokePrivateMethod($listener, 'normalizeStoredAssetPath', ['/assets/build/assets/file.woff2'])
+        );
+    }
+
+    #[DataProvider('buildPayloadProvider')]
+    public function testBuildPayloadStripsFragmentAttrsTokenizesAssetsAndExtractsLocale(
+        string $listenerClass,
+        string $assetBaseToken,
+        string $fragmentName,
+        string $locale,
+        string $cssEntry,
+        string $jsEntry
+    ): void {
+        $listener = new $listenerClass();
+        $destinationPath = $this->tempDir . '/site-output';
+
+        $fragmentPath = $destinationPath . '/fragments/' . $locale . '/' . $fragmentName . '/index.html';
+        $cssArtifactPath = $destinationPath . '/assets/build/assets/' . basename($cssEntry);
+        $jsArtifactPath = $destinationPath . '/assets/build/assets/' . basename($jsEntry);
+
+        $logoPath = $destinationPath . '/assets/images/logo.svg';
+        $fontPath = $destinationPath . '/assets/build/assets/font.woff2';
+
+        $html = <<<HTML
+<div class="fragment-root" data-fragment-css="http://localhost:8081/assets/build/assets/generated.css" data-fragment-js="http://localhost:8081/assets/build/assets/generated.js">
+    <img src="http://localhost:8081/assets/images/logo.svg" alt="Logo">
+    <img src="/assets/images/logo.svg" alt="Logo duplicate">
+</div>
+HTML;
+
+        $css = <<<CSS
+.fragment-root {
+    background-image: url('/assets/images/logo.svg');
+    src: url("/assets/build/assets/font.woff2") format('woff2');
+}
+CSS;
+
+        $js = 'console.log("fragment");';
+
+        $this->writeFile($fragmentPath, $html);
+        $this->writeFile($cssArtifactPath, $css);
+        $this->writeFile($jsArtifactPath, $js);
+        $this->writeFile($logoPath, '<svg></svg>');
+        $this->writeFile($fontPath, 'fake-font');
+
+        $payload = $this->invokePrivateMethod($listener, 'buildPayload', [
+            $fragmentPath,
+            $destinationPath,
+            $cssArtifactPath,
+            $jsArtifactPath,
+        ]);
+
+        self::assertSame($locale, $payload['locale']);
+        self::assertArrayHasKey('generated_at', $payload);
+        self::assertSame(hash('sha256', $payload['html'] . "\n" . $payload['css'] . "\n" . $payload['js']), $payload['version']);
+
+        self::assertStringNotContainsString('data-fragment-css=', $payload['html']);
+        self::assertStringNotContainsString('data-fragment-js=', $payload['html']);
+        self::assertStringContainsString($assetBaseToken . '/images/logo.svg', $payload['html']);
+        self::assertStringContainsString($assetBaseToken . '/images/logo.svg', $payload['css']);
+        self::assertStringContainsString($assetBaseToken . '/build/assets/font.woff2', $payload['css']);
+        self::assertSame($js, $payload['js']);
+
+        self::assertCount(2, $payload['assets']);
+        self::assertSame([
+            'path' => 'images/logo.svg',
+            'content_base64' => base64_encode('<svg></svg>'),
+            'mime' => mime_content_type($logoPath) ?: 'application/octet-stream',
+        ], $payload['assets'][0]);
+        self::assertSame('build/assets/font.woff2', $payload['assets'][1]['path']);
+        self::assertSame(base64_encode('fake-font'), $payload['assets'][1]['content_base64']);
+    }
+
+    #[DataProvider('extractLocaleProvider')]
+    public function testExtractLocaleFromFragmentPathReturnsExpectedValue(
+        string $listenerClass,
+        string $relativePath,
+        string $expectedLocale
+    ): void {
+        $listener = new $listenerClass();
+
+        self::assertSame(
+            $expectedLocale,
+            $this->invokePrivateMethod($listener, 'extractLocaleFromFragmentPath', [$relativePath])
+        );
+    }
+
+    public static function listenerProvider(): iterable
+    {
+        yield 'header' => [PushHeaderFragments::class, 'LIBRESIGN_PUBLISH_HEADER_FRAGMENTS'];
+        yield 'footer' => [PushFooterFragments::class, 'LIBRESIGN_PUBLISH_FOOTER_FRAGMENTS'];
+    }
+
+    public static function fragmentStructureProvider(): iterable
+    {
+        yield 'header fragments' => [
+            PushHeaderFragments::class,
+            'header',
+            [
+                'fragments/fr/header/index.html',
+                'fragments/header/index.html',
+                'fragments/pt-BR/header/index.html',
+            ],
+        ];
+
+        yield 'footer fragments' => [
+            PushFooterFragments::class,
+            'footer',
+            [
+                'fragments/footer/index.html',
+                'fragments/fr/footer/index.html',
+                'fragments/pt-BR/footer/index.html',
+            ],
+        ];
+    }
+
+    public static function buildPayloadProvider(): iterable
+    {
+        yield 'header payload' => [
+            PushHeaderFragments::class,
+            '__LIBRESIGN_HEADER_ASSET_BASE_URL__',
+            'header',
+            'pt-BR',
+            'header-fragment.css',
+            'header-fragment.js',
+        ];
+
+        yield 'footer payload' => [
+            PushFooterFragments::class,
+            '__LIBRESIGN_FOOTER_ASSET_BASE_URL__',
+            'footer',
+            'pt',
+            'footer-fragment.css',
+            'footer-fragment.js',
+        ];
+    }
+
+    public static function extractLocaleProvider(): iterable
+    {
+        yield 'header default locale' => [PushHeaderFragments::class, 'fragments/header/index.html', ''];
+        yield 'header localized locale' => [PushHeaderFragments::class, 'fragments/pt-BR/header/index.html', 'pt-BR'];
+        yield 'header ignores non header path' => [PushHeaderFragments::class, 'fragments/pt-BR/footer/index.html', ''];
+        yield 'footer default locale' => [PushFooterFragments::class, 'fragments/footer/index.html', ''];
+        yield 'footer localized locale' => [PushFooterFragments::class, 'fragments/fr/footer/index.html', 'fr'];
+        yield 'footer ignores non footer path' => [PushFooterFragments::class, 'fragments/fr/header/index.html', ''];
+    }
+
+    /**
+     * @param object $instance
+     * @param array<int, mixed> $args
+     */
+    private function invokePrivateMethod(object $instance, string $method, array $args = []): mixed
+    {
+        $reflection = new ReflectionClass($instance);
+        $methodReflection = $reflection->getMethod($method);
+        $methodReflection->setAccessible(true);
+
+        return $methodReflection->invokeArgs($instance, $args);
+    }
+
+    private function writeFile(string $path, string $contents): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($path, $contents);
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $fullPath = $path . '/' . $item;
+            if (is_dir($fullPath)) {
+                $this->deleteDirectory($fullPath);
+                continue;
+            }
+
+            unlink($fullPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,8 +7,10 @@ export default defineConfig({
         jigsaw({
             input: [
                 'source/_assets/scss/ud-styles.scss',
+                'source/_assets/scss/header-fragment.scss',
                 'source/_assets/scss/footer-fragment.scss',
                 'source/_assets/js/main.js',
+                'source/_assets/js/header-fragment.js',
                 'source/_assets/js/footer-fragment.js',
             ],
             refresh: {


### PR DESCRIPTION
## Summary
- add the shared header fragment template, styles, script, and publisher
- wire the header fragment into the Jigsaw build and layout rendering
- add unit tests covering both header and footer fragment publishers
- wire local webhook publishing for fragment validation

## Validation
- build assets successfully inside the site container
- run PHPUnit in the site container
