### PR TITLE
fix: redirect homepage Try CTA to pricing page

### DIFF
--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -11,7 +11,7 @@
       'description' => $page->t('Reduce bureaucracy and speed up your processes: sign, manage, and validate documents with technology you control.'),
       'actions' => [
         [
-          'href' => 'https://account.libresign.coop/',
+          'href' => locale_url($page, 'pricing'),
           'label' => $page->t('Try LibreSign'),
           'class' => 'btn ud-btn-solid-amber ud-btn-lg w-100 text-center',
         ],


### PR DESCRIPTION
## Summary
- updated the homepage hero primary CTA (`Try LibreSign`) to point to the local pricing page instead of the external account URL
- changed `source/index.blade.php` from `https://account.libresign.coop/` to `locale_url($page, 'pricing')`

## Validation
- built the site inside the project container with `npm run build-assets`
- confirmed generated output in `build_local/index.html` now contains:
  - hero CTA link to `/pricing`
  - label remains `Try LibreSign`

## Why
This makes the user journey more efficient by taking users directly to plans and pricing before signup/contact decisions.