### PR TITLE
fix: remove header/hero gap at specific lg widths

### DIFF
--- a/source/_assets/scss/_header.scss
+++ b/source/_assets/scss/_header.scss
@@ -20,6 +20,14 @@
   }
 }
 
+:root {
+  --ud-header-height: 76px;
+
+  @media #{$lg} {
+    --ud-header-height: 72px;
+  }
+}
+
 .ud-header {
   position: fixed;
   top: 0;
@@ -290,7 +298,7 @@
 
   @media #{$laptop, $lg, $md, $sm, $xs} {
     position: fixed;
-    top: 76px;
+    top: var(--ud-header-height);
     left: 0;
     width: 100vw;
     background-color: var(--color-dark);

--- a/source/_assets/scss/_hero.scss
+++ b/source/_assets/scss/_hero.scss
@@ -15,7 +15,7 @@
   @media #{$xs} {
     background-position: 72% top;
   }
-  margin-top: 76px;
+  margin-top: var(--ud-header-height);
   padding-top: 127px;
   padding-bottom: 88px;
   min-height: 1210px;
@@ -51,7 +51,7 @@
   }
 
   @media #{$xs} {
-    margin-top: 76px;
+    margin-top: var(--ud-header-height);
     padding-top: 80px;
     padding-bottom: 48px;
     min-height: auto;


### PR DESCRIPTION
## Summary
- define a shared `--ud-header-height` CSS variable in header styles
- set default header height to `76px` and adjust to `72px` on the `lg` breakpoint (`992px-1199px`)
- use the shared variable for both hero top offset and collapsed navbar top offset

## Why
At a specific intermediate desktop width, the fixed header height became `72px` while the hero still used a hardcoded `76px` top margin, creating a visible gap between the menu and hero.

## Validation
- verified geometry at affected and nearby widths:
  - `1062px`: gap went from `4px` to `0px`
  - `1200px`, `1400px`, `900px`: no regression (only subpixel rounding where expected)

## Scope
- source-only change in SCSS files:
  - `source/_assets/scss/_header.scss`
  - `source/_assets/scss/_hero.scss`
- no direct/manual edits to `build_*` artifacts

🏚️ Before | 🏡 After
--- | ---
<img width="1049" height="122" alt="image" src="https://github.com/user-attachments/assets/365673bf-cb62-4d79-872c-842c7303f66c" />|<img width="921" height="161" alt="image" src="https://github.com/user-attachments/assets/7a8ca4a1-e87b-4544-8e3d-64276f8cecf3" />
