### PR TITLE
fix(header): use xl breakpoint and animate hamburger icon

### DIFF
--- a/source/_assets/scss/_header.scss
+++ b/source/_assets/scss/_header.scss
@@ -324,6 +324,23 @@
     margin: 5px 0;
     position: relative;
     @include transition(0.3s);
+    transform-origin: center;
+  }
+
+  &[aria-expanded="true"] .toggler-icon:nth-child(1),
+  &:not(.collapsed) .toggler-icon:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
+
+  &[aria-expanded="true"] .toggler-icon:nth-child(2),
+  &:not(.collapsed) .toggler-icon:nth-child(2) {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+
+  &[aria-expanded="true"] .toggler-icon:nth-child(3),
+  &:not(.collapsed) .toggler-icon:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
   }
 }
 

--- a/source/_assets/scss/_header.scss
+++ b/source/_assets/scss/_header.scss
@@ -114,7 +114,11 @@
   gap: 24px;
   align-items: center;
 
-  @media #{$laptop, $lg, $md, $sm, $xs} {
+  @media #{$laptop} {
+    gap: 16px;
+  }
+
+  @media #{$lg, $md, $sm, $xs} {
     gap: 4px;
     align-items: start;
   }
@@ -176,7 +180,7 @@
         color: var(--white);
       }
 
-      @media #{$laptop, $lg, $md, $sm, $xs} {
+      @media #{$lg, $md, $sm, $xs} {
         justify-content: flex-start;
       }
     }
@@ -208,7 +212,7 @@
         }
       }
 
-      @media #{$laptop, $lg, $md, $sm, $xs} {
+      @media #{$lg, $md, $sm, $xs} {
         min-width: 0;
         width: 100%;
         margin-top: 4px;
@@ -279,7 +283,7 @@
 #customer-area-link {
   margin-left: 24px;
 
-  @media #{$laptop, $lg, $md, $sm, $xs} {
+  @media #{$lg, $md, $sm, $xs} {
     margin-left: auto;
     margin-right: auto;
   }
@@ -288,7 +292,7 @@
 .navbar-collapse {
   flex-grow: 0;
 
-  @media #{$laptop, $lg, $md, $sm, $xs} {
+  @media #{$lg, $md, $sm, $xs} {
     position: fixed;
     top: 76px;
     left: 0;

--- a/source/_layouts/header.blade.php
+++ b/source/_layouts/header.blade.php
@@ -1,7 +1,7 @@
 <a href="#main-content" class="skip-to-content">{{ $page->t("Skip to main content") }}</a>
 <header class="ud-header">
   <div class="container">
-      <nav class="navbar navbar-expand-xxl" aria-label="{{ $page->t('Main navigation') }}">
+      <nav class="navbar navbar-expand-xl" aria-label="{{ $page->t('Main navigation') }}">
       <a class="navbar-brand" href="{{ locale_url($page, '')  }}" aria-label="{{ $page->t('LibreSign home') }}">
         <img src="{{ $page->baseUrl }}assets/images/logo/logo.svg" alt="LibreSign">
       </a>

--- a/source/_layouts/header.blade.php
+++ b/source/_layouts/header.blade.php
@@ -133,7 +133,7 @@
             </li>
           </ul>
         </div>
-        <button class="navbar-toggler"
+        <button class="navbar-toggler collapsed"
                 type="button"
                 data-bs-toggle="collapse"
                 data-bs-target="#main-navigation"


### PR DESCRIPTION
## Summary

- lower the navbar collapse breakpoint to `xl` so the menu switches before the header wraps
- keep the responsive menu stable for multilingual content by relying on Bootstrap/CSS only
- animate the hamburger toggler into an `X` when the menu is open

## Validation

- built the site assets in the PHP container with `npm run build-assets`
- verified the menu behavior in the browser at multiple widths
- confirmed the toggler morphs into an `X` via `aria-expanded`/CSS state

<img width="921" height="161" alt="image" src="https://github.com/user-attachments/assets/31b0ee08-58d2-42bd-a7b0-0b38fd83a300" />


<img width="918" height="394" alt="image" src="https://github.com/user-attachments/assets/22ba8869-aa0a-4965-8578-40494bdd0093" />
