### PR TITLE
fix(build): bound WordPress fetch timeouts during site build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,6 @@ jobs:
           php-version: 8.3
       - run: composer i
       - run: composer prod
-      - run: ./vendor/bin/jigsaw build production
       - uses: crazy-max/ghaction-github-pages@v4
         if: success()
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -35,8 +35,6 @@ jobs:
           fi
       - name: Run composer command
         run: composer prod
-      - name: Build production site
-        run: ./vendor/bin/jigsaw build production
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/config.php
+++ b/config.php
@@ -3,6 +3,7 @@
 use App\Support\GitHub\GitHubReleaseDownloadsCounter;
 use App\Support\Pricing\WooCommerceAuthHeadersBuilder;
 use App\Support\Pricing\WooCommerceProductCollection;
+use App\Support\WordPress\WordPressBuildClient;
 use Illuminate\Support\Str;
 use Mni\FrontYAML\Parser;
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
@@ -54,6 +55,7 @@ $wooCommerceAuthenticatedHeaders = (new WooCommerceAuthHeadersBuilder())
     ->build($wooCommerceConsumerKey, $wooCommerceConsumerSecret);
 
 $wooCommerceProductCollection = new WooCommerceProductCollection($wooCommerceAuthenticatedHeaders);
+$wordPressBuildClient = new WordPressBuildClient();
 
 return [
     'production' => false,
@@ -75,9 +77,12 @@ return [
     'locales' => function ($page) {
         return available_locales($page);
     },
-    'wordPressVersion' => function($page) {
-        $version = file_get_contents($page->accountUrl . '/wp-json/libresign/v1/version');
-        return json_decode($version)->version;
+    'wordPressVersion' => function($page) use ($wordPressBuildClient) {
+        if (empty($page->accountUrl)) {
+            return '';
+        }
+
+        return $wordPressBuildClient->fetchVersion($page->accountUrl) ?? '';
     },
     'markdownListToHtml' => function($page, $list) {
         $list = $page->t($list);
@@ -529,44 +534,26 @@ return [
                 }
                 return 'posts/' . $page->slug;
             },
-            'items' => function ($post) {
+            'items' => function ($post) use ($wordPressBuildClient) {
                 if(empty($post->get('accountUrl'))){
                     return [];
                 }
-                $categories = json_decode(file_get_contents($post->get('accountUrl') . '/wp-json/wp/v2/categories'));
-                $categories = array_filter($categories, fn ($c) => $c->slug === 'article');
-                $posts = [];
-                foreach ($categories as $category) {
-                    $baseUrl = $post->get('accountUrl') . '/wp-json/wp/v2/posts?_embed&categories=' . $category->id . '&lang=' . $category->lang;
-                    $headers = get_headers($baseUrl);
-                    $totalPages = 1;
-                    foreach ($headers as $header) {
-                        if (stripos($header, 'X-WP-TotalPages:') !== false) {
-                            $totalPages = (int) trim(substr($header, strpos($header, ':') + 1));
-                            break;
-                        }
-                    }
-                    $page = 1;
-                    while ($page <= $totalPages) {
-                        $url = $baseUrl . '&page=' . $page;
-                        if (!$response = file_get_contents($url)) {
-                            break;
-                        }
-                        $posts = array_merge($posts, json_decode($response, true));
-                        $page++;
-                    };
-                }
+                $posts = $wordPressBuildClient->fetchArticlePosts($post->get('accountUrl'));
+                $wordPressLanguages = $wordPressBuildClient->fetchLanguages($post->get('accountUrl'));
 
-                $wordPressLanguages = json_decode(file_get_contents($post->get('accountUrl') . '/wp-json/pll/v1/languages'));
-                return collect($posts)->map(function ($fromApi) use ($wordPressLanguages, $post) {
-                    $currentLang = current(array_filter($wordPressLanguages, fn ($l) => $l->slug === $fromApi['lang']));
+                return collect($posts)->map(function (array $fromApi) use ($wordPressLanguages, $post) {
+                    $currentLang = current(array_filter(
+                        $wordPressLanguages,
+                        fn (array $language) => ($language['slug'] ?? null) === ($fromApi['lang'] ?? null)
+                    )) ?: [];
+
                     $data = [
                         'title' => $fromApi['title']['rendered'],
                         'slug' => $fromApi['slug'],
                         'date' => Carbon\Carbon::parse($fromApi['date'])->timestamp,
                         'content' => $fromApi['content']['rendered'],
-                        'lang' => $currentLang->w3c ?? $fromApi['lang'],
-                        'langSlug' => $currentLang->slug ?? $fromApi['lang'],
+                        'lang' => $currentLang['w3c'] ?? $fromApi['lang'],
+                        'langSlug' => $currentLang['slug'] ?? $fromApi['lang'],
                         'description' => $fromApi['acf']['description'],
                     ];
                     if (is_array($fromApi['author'])) {

--- a/support/WordPress/WordPressBuildClient.php
+++ b/support/WordPress/WordPressBuildClient.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\WordPress;
+
+class WordPressBuildClient
+{
+    public function __construct(
+        private readonly int $timeout = 15,
+    ) {
+    }
+
+    public function fetchVersion(string $accountUrl): ?string
+    {
+        $response = $this->fetchJson($this->buildUrl($accountUrl, '/wp-json/libresign/v1/version'));
+        $version = $response['version'] ?? null;
+
+        if (! is_scalar($version) || $version === '') {
+            return null;
+        }
+
+        return (string) $version;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function fetchLanguages(string $accountUrl): array
+    {
+        $languages = $this->fetchJson($this->buildUrl($accountUrl, '/wp-json/pll/v1/languages'));
+
+        return is_array($languages) ? array_values($languages) : [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function fetchArticlePosts(string $accountUrl): array
+    {
+        $categories = $this->fetchJson($this->buildUrl($accountUrl, '/wp-json/wp/v2/categories'));
+        if (! is_array($categories)) {
+            return [];
+        }
+
+        $posts = [];
+
+        foreach ($categories as $category) {
+            if (! is_array($category) || ($category['slug'] ?? null) !== 'article') {
+                continue;
+            }
+
+            $categoryId = $category['id'] ?? null;
+            $categoryLang = $category['lang'] ?? null;
+            if (! is_scalar($categoryId) || ! is_scalar($categoryLang) || $categoryLang === '') {
+                continue;
+            }
+
+            $baseUrl = $this->buildUrl(
+                $accountUrl,
+                '/wp-json/wp/v2/posts?_embed&categories=' . rawurlencode((string) $categoryId)
+                . '&lang=' . rawurlencode((string) $categoryLang)
+            );
+
+            $totalPages = $this->extractTotalPages($this->fetchHeaders($baseUrl));
+            $page = 1;
+
+            while ($page <= $totalPages) {
+                $response = $this->fetchJson($baseUrl . '&page=' . $page);
+                if (! is_array($response)) {
+                    break;
+                }
+
+                foreach ($response as $post) {
+                    if (is_array($post)) {
+                        $posts[] = $post;
+                    }
+                }
+
+                $page++;
+            }
+        }
+
+        return $posts;
+    }
+
+    protected function fetchJson(string $url): ?array
+    {
+        $response = $this->fetchContent($url);
+
+        return $response ? (json_decode($response, true) ?: null) : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function fetchHeaders(string $url): array
+    {
+        $headers = @get_headers($url, true, $this->createStreamContext());
+
+        return is_array($headers) ? $headers : [];
+    }
+
+    protected function fetchContent(string $url): string|false
+    {
+        return @file_get_contents($url, false, $this->createStreamContext());
+    }
+
+    protected function createStreamContext(array $headers = [])
+    {
+        $contextOptions = [
+            'http' => [
+                'timeout' => $this->timeout,
+                'ignore_errors' => true,
+            ],
+        ];
+
+        if (! empty($headers)) {
+            $contextOptions['http']['header'] = implode("\r\n", $headers);
+        }
+
+        return stream_context_create($contextOptions);
+    }
+
+    /**
+     * @param array<string, mixed> $headers
+     */
+    private function extractTotalPages(array $headers): int
+    {
+        $totalPages = $headers['X-WP-TotalPages'] ?? $headers['x-wp-totalpages'] ?? null;
+
+        if (is_array($totalPages)) {
+            $totalPages = end($totalPages);
+        }
+
+        $validated = filter_var($totalPages, FILTER_VALIDATE_INT, [
+            'options' => ['min_range' => 1],
+        ]);
+
+        return $validated !== false ? $validated : 1;
+    }
+
+    private function buildUrl(string $accountUrl, string $path): string
+    {
+        return rtrim($accountUrl, '/') . $path;
+    }
+}

--- a/tests/Unit/Support/WordPress/WordPressBuildClientTest.php
+++ b/tests/Unit/Support/WordPress/WordPressBuildClientTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\WordPress;
+
+use App\Support\WordPress\WordPressBuildClient;
+use PHPUnit\Framework\TestCase;
+
+final class WordPressBuildClientTest extends TestCase
+{
+    public function testCreateStreamContextConfiguresTimeoutAndHeaders(): void
+    {
+        $client = new class(7) extends WordPressBuildClient
+        {
+            public function exposeCreateStreamContext(array $headers = [])
+            {
+                return $this->createStreamContext($headers);
+            }
+        };
+
+        $context = $client->exposeCreateStreamContext([
+            'Accept: application/json',
+            'Authorization: Bearer token',
+        ]);
+
+        $options = stream_context_get_options($context);
+
+        self::assertSame(7, $options['http']['timeout']);
+        self::assertTrue($options['http']['ignore_errors']);
+        self::assertSame(
+            "Accept: application/json\r\nAuthorization: Bearer token",
+            $options['http']['header']
+        );
+    }
+
+    public function testFetchVersionReturnsNullWhenEndpointFails(): void
+    {
+        $client = new FakeWordPressBuildClient();
+
+        self::assertNull($client->fetchVersion('https://account.example.test/'));
+    }
+
+    public function testFetchVersionReturnsVersionFromApiResponse(): void
+    {
+        $client = new FakeWordPressBuildClient([
+            'https://account.example.test/wp-json/libresign/v1/version' => [
+                'version' => '2.4.6',
+            ],
+        ]);
+
+        self::assertSame('2.4.6', $client->fetchVersion('https://account.example.test/'));
+    }
+
+    public function testFetchLanguagesReturnsDecodedLanguages(): void
+    {
+        $client = new FakeWordPressBuildClient([
+            'https://account.example.test/wp-json/pll/v1/languages' => [
+                ['slug' => 'en', 'w3c' => 'en-US'],
+                ['slug' => 'pt-br', 'w3c' => 'pt-BR'],
+            ],
+        ]);
+
+        self::assertSame([
+            ['slug' => 'en', 'w3c' => 'en-US'],
+            ['slug' => 'pt-br', 'w3c' => 'pt-BR'],
+        ], $client->fetchLanguages('https://account.example.test/'));
+    }
+
+    public function testFetchArticlePostsAggregatesPaginatedArticleCategories(): void
+    {
+        $accountUrl = 'https://account.example.test/';
+        $categoriesUrl = 'https://account.example.test/wp-json/wp/v2/categories';
+        $englishBaseUrl = 'https://account.example.test/wp-json/wp/v2/posts?_embed&categories=21&lang=en';
+        $portugueseBaseUrl = 'https://account.example.test/wp-json/wp/v2/posts?_embed&categories=22&lang=pt-br';
+
+        $client = new FakeWordPressBuildClient(
+            [
+                $categoriesUrl => [
+                    ['id' => 20, 'slug' => 'news', 'lang' => 'en'],
+                    ['id' => 21, 'slug' => 'article', 'lang' => 'en'],
+                    ['id' => 22, 'slug' => 'article', 'lang' => 'pt-br'],
+                ],
+                $englishBaseUrl . '&page=1' => [
+                    ['id' => 100, 'lang' => 'en'],
+                ],
+                $englishBaseUrl . '&page=2' => [
+                    ['id' => 101, 'lang' => 'en'],
+                ],
+                $portugueseBaseUrl . '&page=1' => [
+                    ['id' => 200, 'lang' => 'pt-br'],
+                ],
+            ],
+            [
+                $englishBaseUrl => ['X-WP-TotalPages' => '2'],
+                $portugueseBaseUrl => ['X-WP-TotalPages' => '1'],
+            ],
+        );
+
+        self::assertSame([
+            ['id' => 100, 'lang' => 'en'],
+            ['id' => 101, 'lang' => 'en'],
+            ['id' => 200, 'lang' => 'pt-br'],
+        ], $client->fetchArticlePosts($accountUrl));
+
+        self::assertSame([
+            $categoriesUrl,
+            $englishBaseUrl . '&page=1',
+            $englishBaseUrl . '&page=2',
+            $portugueseBaseUrl . '&page=1',
+        ], $client->requestedJsonUrls);
+        self::assertSame([
+            $englishBaseUrl,
+            $portugueseBaseUrl,
+        ], $client->requestedHeaderUrls);
+    }
+
+    public function testFetchArticlePostsDefaultsToSinglePageWhenHeadersAreMissing(): void
+    {
+        $accountUrl = 'https://account.example.test';
+        $categoriesUrl = 'https://account.example.test/wp-json/wp/v2/categories';
+        $baseUrl = 'https://account.example.test/wp-json/wp/v2/posts?_embed&categories=21&lang=en';
+
+        $client = new FakeWordPressBuildClient([
+            $categoriesUrl => [
+                ['id' => 21, 'slug' => 'article', 'lang' => 'en'],
+            ],
+            $baseUrl . '&page=1' => [
+                ['id' => 300, 'lang' => 'en'],
+            ],
+        ]);
+
+        self::assertSame([
+            ['id' => 300, 'lang' => 'en'],
+        ], $client->fetchArticlePosts($accountUrl));
+        self::assertSame([$baseUrl], $client->requestedHeaderUrls);
+    }
+}
+
+final class FakeWordPressBuildClient extends WordPressBuildClient
+{
+    /**
+     * @var list<string>
+     */
+    public array $requestedJsonUrls = [];
+
+    /**
+     * @var list<string>
+     */
+    public array $requestedHeaderUrls = [];
+
+    /**
+     * @param array<string, array<mixed>> $jsonResponses
+     * @param array<string, array<string, mixed>> $headerResponses
+     */
+    public function __construct(
+        private readonly array $jsonResponses = [],
+        private readonly array $headerResponses = [],
+    ) {
+        parent::__construct();
+    }
+
+    protected function fetchJson(string $url): ?array
+    {
+        $this->requestedJsonUrls[] = $url;
+
+        return $this->jsonResponses[$url] ?? null;
+    }
+
+    protected function fetchHeaders(string $url): array
+    {
+        $this->requestedHeaderUrls[] = $url;
+
+        return $this->headerResponses[$url] ?? [];
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated WordPress build client with bounded HTTP timeouts for build-time API requests
- route the `config.php` WordPress version, languages, and article post fetches through that client
- add unit coverage for the new timeout-bounded WordPress build client

## Testing
- full PHPUnit suite in the project PHP image
- production Jigsaw build smoke test in the project PHP image