### PR TITLE
chore: make scrool more fluid

### DIFF
--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -59,7 +59,7 @@ AOS.init({
   }
 
   // Attach scroll handler with debounce
-  window.addEventListener("scroll", debounce(handleScrollElements, 10));
+  window.addEventListener("scroll", debounce(handleScrollElements, 10), { passive: true });
 
   // ====== scroll top js
   function scrollTo(element, to = 0, duration = 500) {


### PR DESCRIPTION
Update the scroll event listener to use { passive: true }, signaling to the browser that the handler won’t call preventDefault(). This improves responsiveness during scrolling and reduces the risk of blocking the main thread due to event handling.