### PR TITLE
fix: align synced site fragments with static layout

### DIFF
--- a/source/_assets/js/header-fragment.js
+++ b/source/_assets/js/header-fragment.js
@@ -1,5 +1,5 @@
 const HEADER_ROOT_SELECTOR = '.libresign-site-header-fragment';
-const DESKTOP_BREAKPOINT = 1400;
+const DESKTOP_BREAKPOINT = 1200;
 
 const root = document.querySelector(HEADER_ROOT_SELECTOR);
 

--- a/source/_assets/scss/footer-fragment.scss
+++ b/source/_assets/scss/footer-fragment.scss
@@ -153,28 +153,27 @@
 .libresign-site-footer-fragment .row > [class*="col-"] {
   padding-left: 12px;
   padding-right: 12px;
-  width: 100%;
 }
 
-.libresign-site-footer-fragment .col-12 {
+.libresign-site-footer-fragment .row > .col-12 {
   flex: 0 0 auto;
   width: 100%;
 }
 
 @media (min-width: 576px) {
-  .libresign-site-footer-fragment .col-sm-6 {
+  .libresign-site-footer-fragment .row > .col-sm-6 {
     flex: 0 0 auto;
     width: 50%;
   }
 }
 
 @media (min-width: 992px) {
-  .libresign-site-footer-fragment .col-lg {
+  .libresign-site-footer-fragment .row > .col-lg {
     flex: 1 0 0;
     width: auto;
   }
 
-  .libresign-site-footer-fragment .col-lg-4 {
+  .libresign-site-footer-fragment .row > .col-lg-4 {
     flex: 0 0 auto;
     width: 33.333333%;
   }
@@ -182,6 +181,8 @@
 
 .libresign-site-footer-fragment .ud-footer {
   background: var(--color-dark);
+  padding-top: 0;
+  padding-bottom: 0;
   overflow: hidden;
   position: relative;
   z-index: 1;
@@ -234,6 +235,7 @@
 .libresign-site-footer-fragment .ud-widget .ud-widget-title {
   color: var(--white);
   font-size: 18px;
+  font-weight: 700;
   margin-bottom: 28px;
 }
 

--- a/source/_assets/scss/header-fragment.scss
+++ b/source/_assets/scss/header-fragment.scss
@@ -125,8 +125,8 @@
 }
 
 .libresign-site-header-fragment .mx-auto {
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 .libresign-site-header-fragment .dropdown {
@@ -201,10 +201,13 @@ body.admin-bar .libresign-site-header-fragment__spacer {
 
 .libresign-site-header-fragment .navbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
-  gap: 24px;
   padding: 18px 0;
+}
+
+.libresign-site-header-fragment .navbar-expand-xl {
+  justify-content: space-between;
 }
 
 .libresign-site-header-fragment .navbar-nav.container {
@@ -215,6 +218,7 @@ body.admin-bar .libresign-site-header-fragment__spacer {
 
 .libresign-site-header-fragment .navbar-brand {
   flex: 0 0 auto;
+  margin-right: 16px;
   padding: 0;
 }
 
@@ -250,7 +254,6 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   font-weight: 400;
   color: var(--white);
   padding: 8px 0;
-  min-height: 40px;
   display: inline-flex;
   align-items: center;
 }
@@ -356,9 +359,10 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   opacity: 0.85;
 }
 
-.libresign-site-header-fragment .link-button {
+.libresign-site-header-fragment .nav-item > .nav-link.link-button {
   background-color: var(--amber);
   color: var(--primary-color);
+  min-height: 38px;
   height: 38px;
   border-radius: 32px;
   font-weight: 600;
@@ -369,8 +373,8 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   white-space: nowrap;
 }
 
-.libresign-site-header-fragment .link-button:hover,
-.libresign-site-header-fragment .link-button:focus {
+.libresign-site-header-fragment .nav-item > .nav-link.link-button:hover,
+.libresign-site-header-fragment .nav-item > .nav-link.link-button:focus {
   background-color: var(--amber-hover);
   color: var(--primary-color);
   opacity: 1;
@@ -491,7 +495,7 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   margin: 8px 0;
 }
 
-@media (max-width: 1399px) {
+@media (max-width: 1199px) {
   .libresign-site-header-fragment .navbar {
     gap: 16px;
   }
@@ -580,16 +584,21 @@ body.admin-bar .libresign-site-header-fragment__spacer {
     margin-right: auto;
   }
 
-  .libresign-site-header-fragment .link-button {
+  .libresign-site-header-fragment .nav-item > .nav-link.link-button {
     padding: 0 16px;
   }
 }
 
-@media (min-width: 1400px) {
+@media (min-width: 1200px) {
+  .libresign-site-header-fragment .navbar-expand-xl {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+
   .libresign-site-header-fragment .navbar-collapse {
     display: flex !important;
     align-items: center;
-    justify-content: center;
-    flex: 1 1 auto;
+    flex-basis: auto;
+    justify-content: normal;
   }
 }


### PR DESCRIPTION
## Summary
- align the synced header fragment desktop layout with the static site navigation structure
- harden fragment CSS specificity so WordPress theme styles do not override CTA and footer presentation
- fix footer grid sizing and desktop breakpoint behavior for the synced fragments

## Testing
- docker compose exec php bash -lc "npm run build-assets"
- compared the static site header/footer layout with the synced fragment harness during validation