### PR TITLE
ci(preview): stop waiting for Pages deployment after preview push

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,6 +41,6 @@ jobs:
           pages-base-url: libresign.github.io/site-preview
           deploy-repository: LibreSign/site-preview
           preview-branch: main
-          wait-for-pages-deployment: true
+          wait-for-pages-deployment: false
           token: ${{ secrets.PREVIEW_TOKEN }}
           comment: ${{ github.event.pull_request.user.type != 'Bot' }}


### PR DESCRIPTION
## Problem

Every `Deploy PR previews` run was failing with:

```
No build found - waiting...
Exact commit build not found after 180s
Timed out (180) waiting for build to start
Process completed with exit code 1.
```

The `rossjrw/pr-preview-action` with `wait-for-pages-deployment: true` pushes all files to `LibreSign/site-preview` (confirmed: 21 439 files, 100%) and then polls for a GitHub Pages deployment in that repository. The build never starts within the 180s window, causing every preview deploy to time out.

## Fix

Set `wait-for-pages-deployment: false`.

The files are already on the `site-preview` branch. GitHub Pages will build asynchronously — the workflow does not need to block waiting for that. The preview URL becomes available once Pages propagates, which it does without us holding the runner.

## Change

```diff
-          wait-for-pages-deployment: true
+          wait-for-pages-deployment: false
```