### PR TITLE
fix: load header-fragment.js in main layout to enable nav dropdowns

### DIFF
--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -68,6 +68,7 @@
     </script>
 
     <script type="module" src="{{ rtrim($page->baseUrl, '/') . vite('source/_assets/js/main.js') }}"></script>
+    <script type="module" src="{{ rtrim($page->baseUrl, '/') . vite('source/_assets/js/header-fragment.js') }}"></script>
     @stack('scripts')
 
     <script>


### PR DESCRIPTION
## Problem

After the refactor in commit `8924435` (unify Features dropdown with Solutions mechanism), the old Bootstrap-based dropdown JS was removed from `main.js`. The new custom dropdown logic lives exclusively in `header-fragment.js`, which is only loaded by external fragment consumers (e.g. WordPress) — not by the static site itself.

As a result, the Solutions, Features, and language selector dropdowns stopped working on the static site.

## Fix

Add `header-fragment.js` as a `<script type="module">` tag in `main.blade.php`, alongside the existing `main.js` tag. This is safe because:
- `header-fragment.js` is already a separate Vite entry point
- Its code is wrapped in `if (root) { ... }` so it's a no-op if the header element is absent
- Fragment consumers continue to load it independently via `data-fragment-js`