### PR TITLE
fix: resolve CSS isolation conflicts in language selector when embedded in WordPress

### DIFF
--- a/source/_assets/scss/_header.scss
+++ b/source/_assets/scss/_header.scss
@@ -389,8 +389,9 @@
     z-index: 100;
 
     position: absolute;
-    width: 128px;
+    min-width: 160px;
     background: var(--white);
+    border: none;
     top: 100%;
     margin-top: 16px;
     padding: 8px 16px;
@@ -404,12 +405,17 @@
     flex-direction: column;
     gap: 8px;
 
+    hr {
+      margin: 8px 0;
+    }
+
     &.show {
       display: flex;
     }
 
     .ud-submenu-link {
       color: var(--heading-color);
+      font-size: 15px;
 
       display: flex;
       align-items: center;

--- a/source/_assets/scss/header-fragment.scss
+++ b/source/_assets/scss/header-fragment.scss
@@ -268,7 +268,7 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   text-underline-offset: 6px;
 }
 
-.libresign-site-header-fragment .ud-nav-dropdown-toggle {
+.libresign-site-header-fragment .nav-item .ud-nav-dropdown-toggle {
   background: transparent;
   border: none;
   border-radius: 0;
@@ -397,7 +397,7 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding-right: 12px;
+  padding: 0 12px 0 0;
   cursor: pointer;
 }
 
@@ -415,7 +415,7 @@ body.admin-bar .libresign-site-header-fragment__spacer {
 .libresign-site-header-fragment .selector .ud-submenu {
   z-index: 100;
   position: absolute;
-  width: 128px;
+  min-width: 160px;
   background: var(--white);
   top: 100%;
   margin-top: 16px;
@@ -433,6 +433,9 @@ body.admin-bar .libresign-site-header-fragment__spacer {
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 0;
+  white-space: nowrap;
+  font-weight: 400;
 }
 
 .libresign-site-header-fragment .selector .ud-submenu-link img {
@@ -542,7 +545,7 @@ body.admin-bar .libresign-site-header-fragment__spacer {
 
   .libresign-site-header-fragment .nav-item,
   .libresign-site-header-fragment .nav-item > .nav-link,
-  .libresign-site-header-fragment .ud-nav-dropdown-toggle {
+  .libresign-site-header-fragment .nav-item .ud-nav-dropdown-toggle {
     width: 100%;
     justify-content: flex-start;
   }


### PR DESCRIPTION
## Problem

When the header fragment is loaded in WordPress/WooCommerce, several Bootstrap and theme CSS rules bleed into the language selector dropdown because the fragment CSS lacked explicit overrides. Multiple visual regressions were identified by comparing the static site (`libresign.coop`) against the WordPress-embedded fragment.

## Root causes and fixes

### 1. Header height inflated 76 px → 92 px in WordPress

`.ud-nav-dropdown-toggle` in `header-fragment.scss` was not scoped to `.nav-item`, so `min-height: 40px` and `padding: 8px 0` — intended for the main nav dropdowns (Solutions, Features) — also applied to the language selector button. This added 16 px to the header height.

**Fix:** scope `.ud-nav-dropdown-toggle` rules to `.nav-item .ud-nav-dropdown-toggle` (matching `_header.scss`), and use the `padding` shorthand on `.selector .dropdown-toggle` to explicitly zero out the vertical padding that Bootstrap button resets add.

### 2. Language codes (NB-NO, PT-BR) wrapping to two lines

Bootstrap's `.dropdown-menu a` adds horizontal padding, shrinking the usable space inside the dropdown below what those codes need at runtime.

**Fix:** add `padding: 0` and `white-space: nowrap` to `.selector .ud-submenu-link`.

### 3. Language item text bold in WordPress

`.ud-nav-submenu-link { font-weight: 600 }` (meant for nav submenus) applies to the language links too because they share the class. The `.selector .ud-submenu-link` rule did not override it.

**Fix:** add `font-weight: 400` to `.selector .ud-submenu-link`.

### 4. Dropdown too narrow — "Help translate ✏️" clipped on the right

`width: 128px` was a hard fixed value. The static site happened to reach 160 px only because Bootstrap's `.dropdown-menu { min-width: 10rem }` silently overrode it. The fragment's scoped rule had higher specificity and stayed at 128 px in WordPress, leaving only 96 px of content area — not enough for the CTA text (~114 px).

**Fix:** change `width: 128px` → `min-width: 160px` in both files so the intent is explicit and the dropdown can grow for longer content.

### 5. Dropdown height mismatch between static site and WordPress

Bootstrap's `.dropdown-menu` was adding:
- `border: 1px solid` — 2 px extra height
- `hr { margin: 1rem 0 }` — separator 33 px vs 17 px in the fragment

**Fix (in `_header.scss`):** add `border: none` and `hr { margin: 8px 0 }` inside `.selector .ud-submenu`, making the static site match the fragment's intentional values (both 285 px).

### 6. Font-size mismatch in language items (16 px vs 15 px)

The fragment CSS sets `font-size: 15px` via `.ud-nav-submenu-link`, which applies in WordPress. The static site inherited 16 px from Bootstrap's body because `.ud-nav-submenu-link { font-size: 15px }` in `_header.scss` is nested under `.nav-item .ud-nav-submenu` and does not reach the language selector.

**Fix (in `_header.scss`):** add `font-size: 15px` to `.selector .ud-submenu-link`.

> [!NOTE]
> Only reproducible at WordPress side.

Before|After
---|---
<img width="442" height="658" alt="image" src="https://github.com/user-attachments/assets/d507b7b5-ed02-425c-8754-76c368b3d140" />|<img width="417" height="409" alt="image" src="https://github.com/user-attachments/assets/5d819ed6-05f5-44ef-9b3d-de49c8d48ae9" />
