### PR TITLE
feature: sitemap image support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "samdark/sitemap": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.5"
+        "phpunit/phpunit": "^12.5",
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca622ffc018194c4fd20533718ff32e8",
+    "content-hash": "3049e0cf2923968c8c39c9c4df3dc770",
     "packages": [
         {
             "name": "brick/math",
@@ -5651,6 +5651,58 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5||^8.5||^9.6",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
+            "time": "2024-08-29T18:43:31+00:00"
+        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",

--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -1,24 +1,131 @@
 <?php namespace App\Listeners;
 
-use TightenCo\Jigsaw\Jigsaw;
 use samdark\sitemap\Sitemap;
+use TightenCo\Jigsaw\Jigsaw;
 
 class GenerateSitemap
 {
     public function handle(Jigsaw $jigsaw)
     {
-        $locale = file_get_contents('CNAME');
+        $siteHost = trim((string) file_get_contents('CNAME'));
+        $imageLookup = $this->buildImageLookup($jigsaw, $siteHost);
         $sitemap = new Sitemap($jigsaw->getDestinationPath() . '/sitemap.xml');
 
-        collect($jigsaw->getOutputPaths())->each(function ($path) use ($locale, $sitemap) {
-            if (! $this->isAsset($path)) {
-                $path = count(explode('/', $path)) === 1 ? '/'.$path : $path;
-                $url = 'https://'. $locale . $path;
-                $sitemap->addItem($url, time(), Sitemap::DAILY);
-            }
-        });
+        $jigsaw->getPages()
+            ->each(function ($pageData, $path) use ($siteHost, $imageLookup, $sitemap) {
+                $normalizedPath = $this->normalizeOutputPath((string) $path);
+
+                if ($this->isAsset($normalizedPath)) {
+                    return;
+                }
+
+                $sitemap->addItem(
+                    $this->normalizeSiteUrl($siteHost, $normalizedPath),
+                    time(),
+                    Sitemap::DAILY,
+                    null,
+                    $imageLookup[$normalizedPath] ?? [],
+                );
+            });
 
         $sitemap->write();
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    protected function buildImageLookup(Jigsaw $jigsaw, string $siteHost): array
+    {
+        $lookup = [];
+
+        foreach (['posts', 'posts_wordpress'] as $collectionName) {
+            $collection = $jigsaw->getCollection($collectionName);
+
+            if (! is_iterable($collection)) {
+                continue;
+            }
+
+            foreach ($collection as $item) {
+                $path = $this->normalizeOutputPath($item->getUrl());
+                $images = $this->resolveImages($siteHost, $item);
+
+                if ($images === []) {
+                    continue;
+                }
+
+                $lookup[$path] = $images;
+            }
+        }
+
+        return $lookup;
+    }
+
+    protected function normalizeSiteUrl(string $siteHost, string $path): string
+    {
+        return 'https://' . $siteHost . ($path === '/' ? '/' : '/' . ltrim($path, '/'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function resolveImages(string $siteHost, $page): array
+    {
+        if (! is_object($page)) {
+            return [];
+        }
+
+        $images = [];
+
+        foreach (['banner', 'cover_image'] as $property) {
+            $value = $page->{$property} ?? null;
+
+            if (! is_string($value) || $value === '') {
+                continue;
+            }
+
+            $normalized = $this->normalizeImageUrl($siteHost, $value);
+
+            if ($normalized === null || $this->isDefaultImage($siteHost, $normalized)) {
+                continue;
+            }
+
+            $images[] = $normalized;
+        }
+
+        return array_values(array_unique($images));
+    }
+
+    protected function normalizeOutputPath(string $path): string
+    {
+        $urlPath = parse_url($path, PHP_URL_PATH);
+
+        if (! is_string($urlPath) || $urlPath === '') {
+            return '/';
+        }
+
+        return $urlPath === '/' ? '/' : '/' . ltrim($urlPath, '/');
+    }
+
+    protected function normalizeImageUrl(string $siteHost, string $url): ?string
+    {
+        $trimmed = trim($url);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (filter_var($trimmed, FILTER_VALIDATE_URL)) {
+            return $trimmed;
+        }
+
+        return $this->normalizeSiteUrl($siteHost, $trimmed);
+    }
+
+    protected function isDefaultImage(string $siteHost, string $url): bool
+    {
+        return in_array($url, [
+            $this->normalizeSiteUrl($siteHost, '/assets/images/logo/logo.svg'),
+        ], true);
     }
 
     public function isAsset($path)

--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -74,8 +74,6 @@ class GenerateSitemap
             return [];
         }
 
-        $images = [];
-
         foreach (['banner', 'cover_image'] as $property) {
             $value = $page->{$property} ?? null;
 
@@ -89,10 +87,10 @@ class GenerateSitemap
                 continue;
             }
 
-            $images[] = $normalized;
+            return [$normalized];
         }
 
-        return array_values(array_unique($images));
+        return [];
     }
 
     protected function normalizeOutputPath(string $path): string

--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -46,7 +46,7 @@ class GenerateSitemap
             }
 
             foreach ($collection as $item) {
-                $path = $this->normalizeOutputPath($item->getUrl());
+                $path = $this->normalizeOutputPath($item->getPath());
                 $images = $this->resolveImages($siteHost, $item);
 
                 if ($images === []) {

--- a/tests/Unit/Listeners/GenerateSitemapTest.php
+++ b/tests/Unit/Listeners/GenerateSitemapTest.php
@@ -11,109 +11,161 @@ use TightenCo\Jigsaw\Jigsaw;
 
 final class GenerateSitemapTest extends TestCase
 {
-    #[DataProvider('handleProvider')]
-    public function testHandleGeneratesExpectedSitemap(
-        array $pages,
-        array $collections,
-        array $expectedFragments,
-        array $unexpectedFragments = [],
-    ): void
+    #[DataProvider('resolveImagesProvider')]
+    public function testResolveImagesReturnsExpectedPrimaryImage(object $page, array $expected): void
     {
-        $listener = new GenerateSitemap();
-        $jigsaw = $this->createStub(Jigsaw::class);
-        \org\bovigo\vfs\vfsStream::setup('build');
+        $listener = new TestableGenerateSitemap();
 
-        $destinationPath = \org\bovigo\vfs\vfsStream::url('build');
-
-        $jigsaw->method('getDestinationPath')->willReturn($destinationPath);
-        $jigsaw->method('getPages')->willReturn(new FakePageCollection($pages));
-        $jigsaw->method('getCollection')->willReturnCallback(
-            static fn (string $collectionName) => $collections[$collectionName] ?? null,
-        );
-
-        $listener->handle($jigsaw);
-
-        $xml = file_get_contents($destinationPath . '/sitemap.xml');
-
-        self::assertIsString($xml);
-
-        foreach ($expectedFragments as $fragment) {
-            self::assertStringContainsString($fragment, $xml);
-        }
-
-        foreach ($unexpectedFragments as $fragment) {
-            self::assertStringNotContainsString($fragment, $xml);
-        }
+        self::assertSame($expected, $listener->exposeResolveImages('libresign.coop', $page));
     }
 
-    public static function handleProvider(): iterable
+    public static function resolveImagesProvider(): iterable
     {
-        yield 'collects images from page metadata' => [
-            [
-                '/posts/advanced-security' => (object) ['page' => (object) []],
-                '/posts/libresign-api-guide' => (object) ['page' => (object) []],
-                '/posts/free-and-open-source-software-for-electronic-signatures' => (object) ['page' => (object) []],
-                '/assets/build/assets/main.js' => (object) [
-                    'page' => (object) [
-                        'banner' => '/assets/images/posts/should-not-appear/banner.jpg',
-                    ],
-                ],
-                '/' => (object) [
-                    'page' => (object) [],
-                ],
+        yield 'prefers banner over cover' => [
+            (object) [
+                'banner' => '/assets/images/posts/advanced-security/banner.jpg',
+                'cover_image' => '/assets/images/posts/advanced-security/cover.jpg',
             ],
-            [
+            ['https://libresign.coop/assets/images/posts/advanced-security/banner.jpg'],
+        ];
+
+        yield 'falls back to cover image' => [
+            (object) [
+                'cover_image' => '/assets/images/posts/advanced-security/cover.jpg',
+            ],
+            ['https://libresign.coop/assets/images/posts/advanced-security/cover.jpg'],
+        ];
+
+        yield 'keeps absolute wordpress image' => [
+            (object) [
+                'banner' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
+            ],
+            ['https://cdn.example.com/libresign-api-guide/banner.webp'],
+        ];
+
+        yield 'ignores default logo variants' => [
+            (object) [
+                'banner' => '/assets/images/logo/logo.svg',
+                'cover_image' => '/assets/images/logo/logo.svg',
+            ],
+            [],
+        ];
+    }
+
+    public function testBuildImageLookupCollectsContentImagesFromBothCollections(): void
+    {
+        $listener = new TestableGenerateSitemap();
+        $jigsaw = $this->createStub(Jigsaw::class);
+
+        $jigsaw->method('getCollection')->willReturnCallback(
+            static fn (string $collectionName) => match ($collectionName) {
                 'posts' => [
                     new FakeCollectionItem('/posts/advanced-security', [
                         'banner' => '/assets/images/posts/advanced-security/banner.jpg',
                         'cover_image' => '/assets/images/posts/advanced-security/cover.jpg',
                     ]),
-                    new FakeCollectionItem('/posts/libresign-api-guide', [
-                        'banner' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
-                        'cover_image' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
-                    ]),
                     new FakeCollectionItem('/posts/free-and-open-source-software-for-electronic-signatures', [
                         'banner' => '/assets/images/logo/logo.svg',
-                        'cover_image' => '/assets/images/logo/logo.svg',
                     ]),
                 ],
-            ],
-            [
-                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
-                '<loc>https://libresign.coop/posts/advanced-security</loc>',
-                '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/banner.jpg</image:loc>',
-                '<loc>https://libresign.coop/posts/libresign-api-guide</loc>',
-                '<image:loc>https://cdn.example.com/libresign-api-guide/banner.webp</image:loc>',
-                '<loc>https://libresign.coop/posts/free-and-open-source-software-for-electronic-signatures</loc>',
-                '<loc>https://libresign.coop/</loc>',
-            ],
-            [
-                '<loc>https://libresign.coop/assets/build/assets/main.js</loc>',
-                '<image:loc>https://libresign.coop/assets/images/logo/logo.svg</image:loc>',
-                '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/cover.jpg</image:loc>',
-            ],
-        ];
-
-        yield 'uses posts_wordpress collection too' => [
-            [
-                '/posts/libresign-api-guide' => (object) [
-                    'page' => (object) [],
-                ],
-            ],
-            [
                 'posts_wordpress' => [
                     new FakeCollectionItem('/posts/libresign-api-guide', [
                         'banner' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
                     ]),
                 ],
-            ],
-            [
-                '<loc>https://libresign.coop/posts/libresign-api-guide</loc>',
-                '<image:loc>https://cdn.example.com/libresign-api-guide/banner.webp</image:loc>',
-            ],
-        ];
+                default => null,
+            },
+        );
+
+        self::assertSame([
+            '/posts/advanced-security' => ['https://libresign.coop/assets/images/posts/advanced-security/banner.jpg'],
+            '/posts/libresign-api-guide' => ['https://cdn.example.com/libresign-api-guide/banner.webp'],
+        ], $listener->exposeBuildImageLookup($jigsaw, 'libresign.coop'));
     }
 
+    public function testHandleWritesPrimaryImagesForContentPages(): void
+    {
+        $xml = $this->buildSitemapXml();
+
+        self::assertStringContainsString('<loc>https://libresign.coop/posts/advanced-security</loc>', $xml);
+        self::assertStringContainsString('<image:loc>https://libresign.coop/assets/images/posts/advanced-security/banner.jpg</image:loc>', $xml);
+        self::assertStringContainsString('<loc>https://libresign.coop/posts/libresign-api-guide</loc>', $xml);
+        self::assertStringContainsString('<image:loc>https://cdn.example.com/libresign-api-guide/banner.webp</image:loc>', $xml);
+    }
+
+    public function testHandleSkipsVariantsDefaultImagesAndAssets(): void
+    {
+        $xml = $this->buildSitemapXml();
+
+        self::assertStringContainsString('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">', $xml);
+        self::assertStringNotContainsString('<image:loc>https://libresign.coop/assets/images/posts/advanced-security/cover.jpg</image:loc>', $xml);
+        self::assertStringNotContainsString('<image:loc>https://libresign.coop/assets/images/logo/logo.svg</image:loc>', $xml);
+        self::assertStringNotContainsString('<loc>https://libresign.coop/assets/build/assets/main.js</loc>', $xml);
+    }
+
+    private function buildSitemapXml(): string
+    {
+        $listener = new GenerateSitemap();
+        $jigsaw = $this->createSitemapJigsawStub();
+
+        $listener->handle($jigsaw);
+
+        $xml = file_get_contents(\org\bovigo\vfs\vfsStream::url('build/sitemap.xml'));
+
+        self::assertIsString($xml);
+
+        return $xml;
+    }
+
+    private function createSitemapJigsawStub(): Jigsaw
+    {
+        $jigsaw = $this->createStub(Jigsaw::class);
+        \org\bovigo\vfs\vfsStream::setup('build');
+
+        $jigsaw->method('getDestinationPath')->willReturn(\org\bovigo\vfs\vfsStream::url('build'));
+        $jigsaw->method('getPages')->willReturn(new FakePageCollection([
+            '/posts/advanced-security' => (object) ['page' => (object) []],
+            '/posts/libresign-api-guide' => (object) ['page' => (object) []],
+            '/posts/free-and-open-source-software-for-electronic-signatures' => (object) ['page' => (object) []],
+            '/assets/build/assets/main.js' => (object) ['page' => (object) []],
+            '/' => (object) ['page' => (object) []],
+        ]));
+        $jigsaw->method('getCollection')->willReturnCallback(
+            static fn (string $collectionName) => match ($collectionName) {
+                'posts' => [
+                    new FakeCollectionItem('/posts/advanced-security', [
+                        'banner' => '/assets/images/posts/advanced-security/banner.jpg',
+                        'cover_image' => '/assets/images/posts/advanced-security/cover.jpg',
+                    ]),
+                    new FakeCollectionItem('/posts/free-and-open-source-software-for-electronic-signatures', [
+                        'banner' => '/assets/images/logo/logo.svg',
+                    ]),
+                ],
+                'posts_wordpress' => [
+                    new FakeCollectionItem('/posts/libresign-api-guide', [
+                        'banner' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
+                    ]),
+                ],
+                default => null,
+            },
+        );
+
+        return $jigsaw;
+    }
+
+}
+
+final class TestableGenerateSitemap extends GenerateSitemap
+{
+    public function exposeResolveImages(string $siteHost, object $page): array
+    {
+        return $this->resolveImages($siteHost, $page);
+    }
+
+    public function exposeBuildImageLookup(Jigsaw $jigsaw, string $siteHost): array
+    {
+        return $this->buildImageLookup($jigsaw, $siteHost);
+    }
 }
 
 final class FakeCollectionItem
@@ -137,40 +189,8 @@ final class FakeCollectionItem
 
 final class FakePageCollection
 {
-    /**
-     * @param array<string, object> $items
-     */
     public function __construct(private array $items)
     {
-    }
-
-    public function map(callable $callback): self
-    {
-        $mapped = [];
-
-        foreach ($this->items as $key => $value) {
-            $mapped[$key] = $callback($value, $key);
-        }
-
-        return new self($mapped);
-    }
-
-    public function filter(callable $callback): self
-    {
-        $filtered = [];
-
-        foreach ($this->items as $key => $value) {
-            if ($callback($value, $key)) {
-                $filtered[$key] = $value;
-            }
-        }
-
-        return new self($filtered);
-    }
-
-    public function values(): self
-    {
-        return new self(array_values($this->items));
     }
 
     public function each(callable $callback): self

--- a/tests/Unit/Listeners/GenerateSitemapTest.php
+++ b/tests/Unit/Listeners/GenerateSitemapTest.php
@@ -83,6 +83,31 @@ final class GenerateSitemapTest extends TestCase
         ], $listener->exposeBuildImageLookup($jigsaw, 'libresign.coop'));
     }
 
+    public function testBuildImageLookupUsesCanonicalPathForPreviewUrls(): void
+    {
+        $listener = new TestableGenerateSitemap();
+        $jigsaw = $this->createStub(Jigsaw::class);
+
+        $jigsaw->method('getCollection')->willReturnCallback(
+            static fn (string $collectionName) => match ($collectionName) {
+                'posts' => [
+                    new FakeCollectionItem(
+                        'https://libresign.github.io/site-preview/pr-preview/pr-460/posts/advanced-security',
+                        [
+                            'banner' => '/assets/images/posts/advanced-security/banner.jpg',
+                        ],
+                        '/posts/advanced-security',
+                    ),
+                ],
+                default => null,
+            },
+        );
+
+        self::assertSame([
+            '/posts/advanced-security' => ['https://libresign.coop/assets/images/posts/advanced-security/banner.jpg'],
+        ], $listener->exposeBuildImageLookup($jigsaw, 'libresign.coop'));
+    }
+
     public function testHandleWritesPrimaryImagesForContentPages(): void
     {
         $xml = $this->buildSitemapXml();
@@ -173,12 +198,18 @@ final class FakeCollectionItem
     public function __construct(
         private string $url,
         private array $attributes,
+        private ?string $path = null,
     ) {
     }
 
     public function getUrl(): string
     {
         return $this->url;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path ?? $this->url;
     }
 
     public function __get(string $name): mixed

--- a/tests/Unit/Listeners/GenerateSitemapTest.php
+++ b/tests/Unit/Listeners/GenerateSitemapTest.php
@@ -82,7 +82,6 @@ final class GenerateSitemapTest extends TestCase
                 '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
                 '<loc>https://libresign.coop/posts/advanced-security</loc>',
                 '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/banner.jpg</image:loc>',
-                '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/cover.jpg</image:loc>',
                 '<loc>https://libresign.coop/posts/libresign-api-guide</loc>',
                 '<image:loc>https://cdn.example.com/libresign-api-guide/banner.webp</image:loc>',
                 '<loc>https://libresign.coop/posts/free-and-open-source-software-for-electronic-signatures</loc>',
@@ -91,6 +90,7 @@ final class GenerateSitemapTest extends TestCase
             [
                 '<loc>https://libresign.coop/assets/build/assets/main.js</loc>',
                 '<image:loc>https://libresign.coop/assets/images/logo/logo.svg</image:loc>',
+                '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/cover.jpg</image:loc>',
             ],
         ];
 

--- a/tests/Unit/Listeners/GenerateSitemapTest.php
+++ b/tests/Unit/Listeners/GenerateSitemapTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Listeners;
+
+use App\Listeners\GenerateSitemap;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use TightenCo\Jigsaw\Jigsaw;
+
+final class GenerateSitemapTest extends TestCase
+{
+    #[DataProvider('handleProvider')]
+    public function testHandleGeneratesExpectedSitemap(
+        array $pages,
+        array $collections,
+        array $expectedFragments,
+        array $unexpectedFragments = [],
+    ): void
+    {
+        $listener = new GenerateSitemap();
+        $jigsaw = $this->createStub(Jigsaw::class);
+        \org\bovigo\vfs\vfsStream::setup('build');
+
+        $destinationPath = \org\bovigo\vfs\vfsStream::url('build');
+
+        $jigsaw->method('getDestinationPath')->willReturn($destinationPath);
+        $jigsaw->method('getPages')->willReturn(new FakePageCollection($pages));
+        $jigsaw->method('getCollection')->willReturnCallback(
+            static fn (string $collectionName) => $collections[$collectionName] ?? null,
+        );
+
+        $listener->handle($jigsaw);
+
+        $xml = file_get_contents($destinationPath . '/sitemap.xml');
+
+        self::assertIsString($xml);
+
+        foreach ($expectedFragments as $fragment) {
+            self::assertStringContainsString($fragment, $xml);
+        }
+
+        foreach ($unexpectedFragments as $fragment) {
+            self::assertStringNotContainsString($fragment, $xml);
+        }
+    }
+
+    public static function handleProvider(): iterable
+    {
+        yield 'collects images from page metadata' => [
+            [
+                '/posts/advanced-security' => (object) ['page' => (object) []],
+                '/posts/libresign-api-guide' => (object) ['page' => (object) []],
+                '/posts/free-and-open-source-software-for-electronic-signatures' => (object) ['page' => (object) []],
+                '/assets/build/assets/main.js' => (object) [
+                    'page' => (object) [
+                        'banner' => '/assets/images/posts/should-not-appear/banner.jpg',
+                    ],
+                ],
+                '/' => (object) [
+                    'page' => (object) [],
+                ],
+            ],
+            [
+                'posts' => [
+                    new FakeCollectionItem('/posts/advanced-security', [
+                        'banner' => '/assets/images/posts/advanced-security/banner.jpg',
+                        'cover_image' => '/assets/images/posts/advanced-security/cover.jpg',
+                    ]),
+                    new FakeCollectionItem('/posts/libresign-api-guide', [
+                        'banner' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
+                        'cover_image' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
+                    ]),
+                    new FakeCollectionItem('/posts/free-and-open-source-software-for-electronic-signatures', [
+                        'banner' => '/assets/images/logo/logo.svg',
+                        'cover_image' => '/assets/images/logo/logo.svg',
+                    ]),
+                ],
+            ],
+            [
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
+                '<loc>https://libresign.coop/posts/advanced-security</loc>',
+                '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/banner.jpg</image:loc>',
+                '<image:loc>https://libresign.coop/assets/images/posts/advanced-security/cover.jpg</image:loc>',
+                '<loc>https://libresign.coop/posts/libresign-api-guide</loc>',
+                '<image:loc>https://cdn.example.com/libresign-api-guide/banner.webp</image:loc>',
+                '<loc>https://libresign.coop/posts/free-and-open-source-software-for-electronic-signatures</loc>',
+                '<loc>https://libresign.coop/</loc>',
+            ],
+            [
+                '<loc>https://libresign.coop/assets/build/assets/main.js</loc>',
+                '<image:loc>https://libresign.coop/assets/images/logo/logo.svg</image:loc>',
+            ],
+        ];
+
+        yield 'uses posts_wordpress collection too' => [
+            [
+                '/posts/libresign-api-guide' => (object) [
+                    'page' => (object) [],
+                ],
+            ],
+            [
+                'posts_wordpress' => [
+                    new FakeCollectionItem('/posts/libresign-api-guide', [
+                        'banner' => 'https://cdn.example.com/libresign-api-guide/banner.webp',
+                    ]),
+                ],
+            ],
+            [
+                '<loc>https://libresign.coop/posts/libresign-api-guide</loc>',
+                '<image:loc>https://cdn.example.com/libresign-api-guide/banner.webp</image:loc>',
+            ],
+        ];
+    }
+
+}
+
+final class FakeCollectionItem
+{
+    public function __construct(
+        private string $url,
+        private array $attributes,
+    ) {
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function __get(string $name): mixed
+    {
+        return $this->attributes[$name] ?? null;
+    }
+}
+
+final class FakePageCollection
+{
+    /**
+     * @param array<string, object> $items
+     */
+    public function __construct(private array $items)
+    {
+    }
+
+    public function map(callable $callback): self
+    {
+        $mapped = [];
+
+        foreach ($this->items as $key => $value) {
+            $mapped[$key] = $callback($value, $key);
+        }
+
+        return new self($mapped);
+    }
+
+    public function filter(callable $callback): self
+    {
+        $filtered = [];
+
+        foreach ($this->items as $key => $value) {
+            if ($callback($value, $key)) {
+                $filtered[$key] = $value;
+            }
+        }
+
+        return new self($filtered);
+    }
+
+    public function values(): self
+    {
+        return new self(array_values($this->items));
+    }
+
+    public function each(callable $callback): self
+    {
+        foreach ($this->items as $key => $value) {
+            $callback($value, $key);
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Follow-up to:
- https://github.com/LibreSign/site/pull/455

**Objective:** add post images to the sitemap.  
Posts have two image variants, but only the primary one is currently included.

**Validate:**  
The file: https://github.com/LibreSign/site-preview/blob/main/pr-preview/pr-460/sitemap.xml  
Should include `image:image`.

It can also be verified here:  
https://libresign.github.io/site-preview/pr-preview/pr-460/sitemap.xml

Compare with production. There you should not find `image:image`:  
https://libresign.coop/sitemap.xml