### PR TITLE
fix: add action deploy to PR

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -44,6 +44,7 @@ jobs:
         if: steps.pr.outputs.number != ''
         uses: rossjrw/pr-preview-action@v1
         with:
+          action: deploy
           source-dir: ./build_production/
           pr-number: ${{ steps.pr.outputs.number }}
           pages-base-url: libresign.github.io/site-preview


### PR DESCRIPTION
The parametter action have 3 values:
- deploy - create and deploy the preview, overwriting any existing preview in that location.
- remove - remove the preview.
- auto - determine whether to deploy or remove the preview based on the emitted event. If the event is pull_request, it will deploy the preview when the event type is opened, reopened and synchronize, and remove it on closed events. Does not do anything for other events or event types, even if you explicitly instruct the workflow to run on them.
- none and all other values: does not do anything.

The default is: auto

You can found more details at README of Action that make the preview: https://github.com/rossjrw/pr-preview-action