### PR TITLE
fix(preview): pass PR number via artifact

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Run composer command
         run: composer prod
 
+      - name: Save PR number
+        run: printf '%s\n' '${{ github.event.pull_request.number }}' > preview-pr-number.txt
+
+      - name: Upload PR number artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-pr-number
+          path: preview-pr-number.txt
+          retention-days: 1
+
       - name: Upload preview build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -4,6 +4,16 @@ on:
   workflow_run:
     workflows: ["Preview Build"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Preview Build run ID
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
   pull_request_target:
     branches: [ main ]
     types: [closed]
@@ -20,25 +30,41 @@ concurrency:
 jobs:
   deploy-preview:
     if: >
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request'
+      ) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve preview build run ID
+        id: source
+        run: |
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            echo 'run_id=${{ inputs.run_id }}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run_id=${{ github.event.workflow_run.id }}' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download PR number artifact
+        if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v4
         with:
           name: preview-pr-number
           path: ${{ runner.temp }}/preview-metadata/
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract PR number
+      - name: Resolve PR number
         id: pr
         run: |
-          pr_number=$(< '${{ runner.temp }}/preview-metadata/preview-pr-number.txt')
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            pr_number='${{ inputs.pr_number }}'
+          else
+            pr_number=$(< '${{ runner.temp }}/preview-metadata/preview-pr-number.txt')
+          fi
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Download preview build artifact
@@ -47,7 +73,7 @@ jobs:
         with:
           name: preview-build
           path: build_production/
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy preview

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -4,16 +4,6 @@ on:
   workflow_run:
     workflows: ["Preview Build"]
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      run_id:
-        description: Preview Build run ID
-        required: true
-        type: string
-      pr_number:
-        description: Pull request number
-        required: true
-        type: string
   pull_request_target:
     branches: [ main ]
     types: [closed]
@@ -30,41 +20,25 @@ concurrency:
 jobs:
   deploy-preview:
     if: >
-      (
-        github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'pull_request'
-      ) || github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve preview build run ID
-        id: source
-        run: |
-          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
-            echo 'run_id=${{ inputs.run_id }}' >> "$GITHUB_OUTPUT"
-          else
-            echo 'run_id=${{ github.event.workflow_run.id }}' >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Download PR number artifact
-        if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v4
         with:
           name: preview-pr-number
           path: ${{ runner.temp }}/preview-metadata/
-          run-id: ${{ steps.source.outputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve PR number
+      - name: Extract PR number
         id: pr
         run: |
-          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
-            pr_number='${{ inputs.pr_number }}'
-          else
-            pr_number=$(< '${{ runner.temp }}/preview-metadata/preview-pr-number.txt')
-          fi
+          pr_number=$(< '${{ runner.temp }}/preview-metadata/preview-pr-number.txt')
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Download preview build artifact
@@ -73,7 +47,7 @@ jobs:
         with:
           name: preview-build
           path: build_production/
-          run-id: ${{ steps.source.outputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy preview

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,10 +25,18 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Extract PR number from workflow_run payload
+      - name: Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-pr-number
+          path: ${{ runner.temp }}/preview-metadata/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract PR number
         id: pr
         run: |
-          pr_number=$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")
+          pr_number=$(< '${{ runner.temp }}/preview-metadata/preview-pr-number.txt')
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Download preview build artifact

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,6 +25,8 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download PR number artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- save the PR number as a small artifact in `Preview Build`
- read that artifact in `Deploy PR previews` instead of relying on `workflow_run.pull_requests`
- keep the deploy workflow logic small and predictable

## Testing
- validated both workflow files with no YAML errors
- inspected recent Actions runs and confirmed `workflow_run` was being created, but deploy steps could be skipped when the PR number was missing from the payload
